### PR TITLE
Bugfix/hit non dialog buttons

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -144,6 +144,7 @@ class Game
   end
 
   def active_player
+    @logger.debug "Game: Fetching active player out of list of players"
     players[currentPlayer]
   end
 

--- a/game_driver.rb
+++ b/game_driver.rb
@@ -65,6 +65,7 @@ class GameDriver
     end
 
     def active_player
+        @logger.debug "GameDriver: Getting active_player from game"
         @game.active_player
     end
 

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -37,12 +37,15 @@ class GameGui < Gosu::Window
 
     def button_up(id)
         if @left_click_down
-            puts "left button released"
+            @logger.debug "left button released"
             @left_click_down = false
             if @current_dialog != nil && @current_dialog.is_visible?
+                @logger.debug "There is a current dialog"
                 if @current_dialog.handle_result
+                    @logger.debug "Handling dialog result"
                     @current_dialog.hide
                 end
+                @logger.debug "Handle result call false so return"
                 return
             end
             if @are_you_sure_dialog.is_visible?
@@ -69,11 +72,14 @@ class GameGui < Gosu::Window
             end
             clickedCard = 0
             @current_displayed_cards.each do |cardButton|
+                @logger.debug "Checking card '#{cardButton}'"
                 if cardButton.is_clicked?
+                    @logger.debug "Awaiting active_player from game_driver"
                     activePlayer = @new_game_driver.await.active_player.value
 
+                    @logger.debug "Getting card from players hand"
                     cardToPlay = activePlayer.remove_card_from_hand(clickedCard)
-                    puts "you clicked a card button #{cardToPlay}"
+                    @logger.debug "you clicked a card button #{cardToPlay}"
 
                     @play_card_future = @new_game_driver.async.post_card_play_clean_up(activePlayer, cardToPlay)
                     @play_card_future.add_observer do |time, value|

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -74,8 +74,10 @@ class GameGui < Gosu::Window
             @current_displayed_cards.each do |cardButton|
                 @logger.debug "Checking card '#{cardButton}'"
                 if cardButton.is_clicked?
-                    @logger.debug "Awaiting active_player from game_driver"
-                    activePlayer = @new_game_driver.await.active_player.value
+                    @logger.debug "Starting awaiting active_player from game_driver"
+                    active_player_result = @new_game_driver.await.active_player
+                    @logger.debug "Get activePlayer value out of await result"
+                    activePlayer = active_player_result.value
 
                     @logger.debug "Getting card from players hand"
                     cardToPlay = activePlayer.remove_card_from_hand(clickedCard)

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -42,8 +42,8 @@ class GameGui < Gosu::Window
             if @current_dialog != nil && @current_dialog.is_visible?
                 if @current_dialog.handle_result
                     @current_dialog.hide
-                    return
                 end
+                return
             end
             if @are_you_sure_dialog.is_visible?
                 @are_you_sure_dialog.handle_result do |clicked|


### PR DESCRIPTION
#28 Shows how there is still an issue here, but this will fix will sidestep that issue since this is not expected to work in the first place. All this fix does (besides ad lots of debug lines for future debugability) Is move the return to outside of handling the result in the dialog this way even if the dialog result isn't handled no other code handling the click will be called.