### PR TITLE
Feature/generate prompts at startup

### DIFF
--- a/game_gui.rb
+++ b/game_gui.rb
@@ -203,9 +203,9 @@ class GameGui < Gosu::Window
     end
 
     # "TrueGuiInterface" stuff... well it used to be
-    def display_list_dialog(list, prompt="Select an option")
-        @logger.debug "GameGui::display_list_dialog called with prompt: '#{prompt}'"
-        @current_dialog.set_prompt prompt
+    def display_list_dialog(list, prompt_key)
+        @logger.debug "GameGui::display_list_dialog called with prompt_key: '#{prompt_key}'"
+        @current_dialog.set_prompt prompt_key
         @current_dialog.reset_result
         @current_dialog.set_cards(list)
         @current_dialog.show

--- a/game_interface.rb
+++ b/game_interface.rb
@@ -30,6 +30,7 @@ class BaseTextInterface
   end
 
   def choose_from_list(card_list, prompt_key)
+    if !prompt_key; raise "prompt_key missing"; end
     if !@prompts.has_key? prompt_key; raise "prompt_key missing from prompts collection"; end
     @output_stream.puts @prompts[prompt_key]
     @output_stream.puts StringFormattingUtilities.indexed_display(card_list)

--- a/game_interface.rb
+++ b/game_interface.rb
@@ -29,13 +29,9 @@ class BaseTextInterface
     @prompts = @prompts.merge(prompts)
   end
 
-  def choose_from_list(card_list, prompt="Choose an option")
-    if prompt.is_a?(String)
-      @output_stream.puts prompt
-    else # assumed to be symbol
-      if !@prompts.has_key? prompt; raise "prompt_key missing from prompts collection"; end
-      @output_stream.puts @prompts[prompt]
-    end
+  def choose_from_list(card_list, prompt_key)
+    if !@prompts.has_key? prompt_key; raise "prompt_key missing from prompts collection"; end
+    @output_stream.puts @prompts[prompt_key]
     @output_stream.puts StringFormattingUtilities.indexed_display(card_list)
     whichCard = get_input.to_i
     card_list.delete_at(whichCard)

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -66,7 +66,6 @@ class CardDialog
         @item_spacing = 10
         @dialog_prompts = dialog_prompts
         @current_prompt_image = dialog_prompts[:default]
-        @draw_prompt_image = false
     end
 
     def add_prompt(symbol, prompt_image)
@@ -91,11 +90,7 @@ class CardDialog
     def draw
         if @visible
             @baground_image.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, 0.25, 0.25)
-            if @draw_prompt_image
-                @current_prompt_image.draw(@dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
-            else
-                @font.draw_text(@prompt, @dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
-            end
+            @current_prompt_image.draw(@dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
             @card_buttons.each do |card_button|
                 card_button.draw
             end
@@ -128,18 +123,10 @@ class CardDialog
         @selected_card = nil
     end
 
-    def set_prompt(prompt)
-        @logger.debug "set_prompt: got prompt: '#{prompt}'"
-        if prompt.is_a?(String)
-            @logger.debug "Prompt is_a string"
-            @prompt = prompt
-            @draw_prompt_image = false
-        else
-            @logger.debug "prompt is_a symb"
-            if !@dialog_prompts.has_key? prompt; raise "prompt_key missing from prompts collection"; end
-            @current_prompt_image = @dialog_prompts[prompt]
-            @draw_prompt_image = true
-        end
+    def set_prompt(prompt_key)
+        @logger.debug "set_prompt: got prompt_key: '#{prompt_key}'"
+        if !@dialog_prompts.has_key? prompt_key; raise "prompt_key missing from prompts collection"; end
+        @current_prompt_image = @dialog_prompts[prompt_key]
     end
 
     def handle_result

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -125,6 +125,7 @@ class CardDialog
 
     def set_prompt(prompt_key)
         @logger.debug "set_prompt: got prompt_key: '#{prompt_key}'"
+        if !prompt_key; raise "prompt_key is nil"; end
         if !@dialog_prompts.has_key? prompt_key; raise "prompt_key missing from prompts collection"; end
         @current_prompt_image = @dialog_prompts[prompt_key]
     end

--- a/tests/game_interface_spec.rb
+++ b/tests/game_interface_spec.rb
@@ -7,20 +7,6 @@ describe "TestInterface" do
     test_outfile = Tempfile.new 'test_output'
 
     describe "choose_from_list" do
-        it "should output the exact string when one is passed" do
-            # setup
-            input_stream = StringIO.new("0")
-            sut = TestInterface.new(input_stream, test_outfile)
-            expected_prompt = "Some expected prompt"
-
-            # execute
-            sut.choose_from_list([1,2,3], expected_prompt)
-
-            # test
-            test_outfile.rewind
-            expect(test_outfile.read).to include expected_prompt
-        end
-
         it "should not output the exact symbol text" do
             # setup
             input_stream = StringIO.new("0")
@@ -54,6 +40,17 @@ describe "TestInterface" do
             expect do
                 sut.choose_from_list([1,2,3], :missing_key)
             end.to raise_error("prompt_key missing from prompts collection")
+        end
+
+        it "should raise an error when nil is passed as prompt_key" do
+            # setup
+            input_stream = StringIO.new("0")
+            sut = TestInterface.new(input_stream, $stdout)
+
+            # execute & test
+            expect do
+                sut.choose_from_list([1,2,3], nil)
+            end.to raise_error("prompt_key missing")
         end
     end
 end

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -6,32 +6,6 @@ describe "CardDialog" do
     test_outfile = Tempfile.new 'test_output'
 
     describe "set_prompt" do
-        it "should draw_text with the prompt value given its set and then draw is called" do
-            # setup
-            gui_double = double("gui")
-            background_double = double("background", draw: nil)
-            font_double = instance_double("font", draw_text: nil)
-            input_stream = StringIO.new("")
-            test_logger = Logger.new(test_outfile)
-            sut = CardDialog.new(
-                gui_double,
-                background_double,
-                font_double,
-                test_logger,
-                {})
-            expected_prompt_text = "Some prompt text"
-
-            # setup lite
-            sut.set_prompt(expected_prompt_text)
-            sut.show
-
-            # set expectations (Assertaions, Test) first
-            expect(font_double).to receive(:draw_text).with(expected_prompt_text, any_args)
-
-            # execute
-            sut.draw
-        end
-
         it "should not call draw_text on font when prompt symbol is passed" do
             # setup
             gui_double = double("gui")

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -33,6 +33,26 @@ describe "CardDialog" do
             sut.draw
         end
 
+        it "should raise an error if the prompt_key is nil" do
+            # setup
+            gui_double = double("gui")
+            background_double = double("background", draw: nil)
+            font_double = instance_double("font", draw_text: nil)
+            input_stream = StringIO.new("")
+            test_logger = Logger.new(test_outfile)
+            sut = CardDialog.new(
+                gui_double,
+                background_double,
+                font_double,
+                test_logger,
+                {})
+
+            # Execute and Assert this should not fail
+            expect do
+                sut.set_prompt(nil)
+            end.to raise_error("prompt_key is nil")
+        end
+
         it "should raise an error if the prompt is a symbol which doesn't exist in the dialog_prompts" do
             # setup
             gui_double = double("gui")


### PR DESCRIPTION
After seeking from help from the Gosu community it seems that it is not well suited to generate assets on the fly. So the recommendation at this time is to generate them at start up and then just determine when they are drawn. This should start with the prompts since those are the assets that I am currently being created in an ad-hoc fashion.