### PR TITLE
Feature/enable static prompt use in gui dialog

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -100,7 +100,7 @@ class Game
       removed_card_result = @interface.await.choose_from_list(player.hand, "Player #{player} Select a card to discard")
       @logger.debug "Game::discardDownToLimit: What state is the removed_card_result: #{removed_card_result.state}"
       if removed_card_result.state != :fulfilled
-        @logger.debug "choose_result may not have been fulfilled because #{removed_card_result.reason}"
+        @logger.info "choose_result may not have been fulfilled because #{removed_card_result.reason}"
       end
       card_to_remove = removed_card_result.value
       @discardPile << card_to_remove

--- a/game.rb
+++ b/game.rb
@@ -97,9 +97,14 @@ class Game
   def discardDownToLimit(player)
     @logger.debug "The hand limit is #{@ruleBase.handLimit}"
     while player.hand.count > @ruleBase.handLimit
-      removedCard = @interface.await.choose_from_list(player.hand, "Player #{player} Select a card to discard").value
-      @discardPile << removedCard
-      @logger.debug "removing '#{removedCard}'"
+      removed_card_result = @interface.await.choose_from_list(player.hand, "Player #{player} Select a card to discard")
+      @logger.debug "Game::discardDownToLimit: What state is the removed_card_result: #{removed_card_result.state}"
+      if removed_card_result.state != :fulfilled
+        @logger.debug "choose_result may not have been fulfilled because #{removed_card_result.reason}"
+      end
+      card_to_remove = removed_card_result.value
+      @discardPile << card_to_remove
+      @logger.debug "removing '#{card_to_remove}'"
     end
   end
 

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -194,8 +194,14 @@ class GameGui < Gosu::Window
 
     # "TrueGuiInterface" stuff... well it used to be
     def display_list_dialog(list, prompt="Select an option")
-        @logger.debug "does this even get called?"
-        @current_dialog.set_prompt prompt
+        @logger.debug "GameGui::display_list_dialog called with prompt: '#{prompt}'"
+        if prompt.is_a?(String)
+            @logger.debug "Prompt is_a string"
+            @current_dialog.set_prompt(prompt, :default)
+        else
+            @logger.debug "prompt is_a symb"
+            @current_dialog.set_prompt("", prompt)
+        end
         @current_dialog.reset_result
         @current_dialog.set_cards(list)
         @current_dialog.show

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -195,13 +195,7 @@ class GameGui < Gosu::Window
     # "TrueGuiInterface" stuff... well it used to be
     def display_list_dialog(list, prompt="Select an option")
         @logger.debug "GameGui::display_list_dialog called with prompt: '#{prompt}'"
-        if prompt.is_a?(String)
-            @logger.debug "Prompt is_a string"
-            @current_dialog.set_prompt(prompt, :default)
-        else
-            @logger.debug "prompt is_a symb"
-            @current_dialog.set_prompt("", prompt)
-        end
+        @current_dialog.set_prompt prompt
         @current_dialog.reset_result
         @current_dialog.set_cards(list)
         @current_dialog.show

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -41,7 +41,7 @@ class GameGui < Gosu::Window
     end
 
     def initialize_dialog_prompts
-        return {default: Gosu::Image.from_text("Some default prompt", 20), discard_down_to_limit: Gosu::Image.from_text("Player player2 Select a card to discard", 20)}
+        return {default: Gosu::Image.from_text("Some default prompt", 20), discard_down_to_limit: Gosu::Image.from_text("Player playerX Select a card to discard", 20)}
     end
 
     def button_up(id)

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -30,13 +30,18 @@ class GameGui < Gosu::Window
             self,
             Gosu::Image.new("assets/onlineGreenSquare2.png", tileable: true),
             Gosu::Font.new(20),
-            logger)
+            logger,
+            initialize_dialog_prompts)
         @new_game_driver = nil
 
         @current_cached_player = nil
         @current_player_future = nil
 
         @play_card_future = nil
+    end
+
+    def initialize_dialog_prompts
+        return {default: Gosu::Image.from_text("Some default prompt", 20), discard_down_to_limit: Gosu::Image.from_text("Player player2 Select a card to discard", 20)}
     end
 
     def button_up(id)

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -124,8 +124,11 @@ class CardDialog
     end
 
     def set_prompt(text, prompt_key)
+        @logger.debug "set_prompt: got text: '#{text}' & prompt_key: '#{prompt_key}'"
         should_change_current_prompt  = prompt_key != :default
+        @logger.debug "set_prompt: change current_prompt_image cond: '#{should_change_current_prompt}'"
         if should_change_current_prompt
+            @logger.debug "set_prompt: dialog_prompts contents: #{@dialog_prompts}"
             @current_prompt_image = @dialog_prompts[prompt_key]
             @current_prompt_changed = true
             return

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -50,7 +50,7 @@ class Dialog
 end
 
 class CardDialog
-    def initialize(window, background, font, logger)
+    def initialize(window, background, font, logger, dialog_prompts)
         @window = window
         @logger = logger
         @visible = false
@@ -64,6 +64,7 @@ class CardDialog
         @dialog_content_x_position = @dialog_x_position + @boarder_width
         @dialog_content_y_position = @dialog_y_position + @boarder_width
         @item_spacing = 10
+        @dialog_prompts = dialog_prompts
     end
 
     def set_cards(card_list)

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -123,18 +123,18 @@ class CardDialog
         @selected_card = nil
     end
 
-    def set_prompt(text, prompt_key)
-        @logger.debug "set_prompt: got text: '#{text}' & prompt_key: '#{prompt_key}'"
-        should_change_current_prompt  = prompt_key != :default
-        @logger.debug "set_prompt: change current_prompt_image cond: '#{should_change_current_prompt}'"
-        if should_change_current_prompt
+    def set_prompt(prompt)
+        @logger.debug "set_prompt: got prompt: '#{prompt}'"
+        if prompt.is_a?(String)
+            @logger.debug "Prompt is_a string"
+            @prompt = prompt
+            @current_prompt_changed = false
+        else
+            @logger.debug "prompt is_a symb"
             @logger.debug "set_prompt: dialog_prompts contents: #{@dialog_prompts}"
-            @current_prompt_image = @dialog_prompts[prompt_key]
+            @current_prompt_image = @dialog_prompts[prompt]
             @current_prompt_changed = true
-            return
         end
-        @prompt = text
-        @current_prompt_changed = false
     end
 
     def handle_result

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -66,7 +66,7 @@ class CardDialog
         @item_spacing = 10
         @dialog_prompts = dialog_prompts
         @current_prompt_image = dialog_prompts[:default]
-        @current_prompt_changed = false
+        @draw_prompt_image = false
     end
 
     def set_cards(card_list)
@@ -86,7 +86,7 @@ class CardDialog
     def draw
         if @visible
             @baground_image.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, 0.25, 0.25)
-            if @current_prompt_changed
+            if @draw_prompt_image
                 @current_prompt_image.draw(@dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
             else
                 @font.draw_text(@prompt, @dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
@@ -128,12 +128,12 @@ class CardDialog
         if prompt.is_a?(String)
             @logger.debug "Prompt is_a string"
             @prompt = prompt
-            @current_prompt_changed = false
+            @draw_prompt_image = false
         else
             @logger.debug "prompt is_a symb"
             @logger.debug "set_prompt: dialog_prompts contents: #{@dialog_prompts}"
             @current_prompt_image = @dialog_prompts[prompt]
-            @current_prompt_changed = true
+            @draw_prompt_image = true
         end
     end
 

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -66,6 +66,7 @@ class CardDialog
         @item_spacing = 10
         @dialog_prompts = dialog_prompts
         @current_prompt_image = dialog_prompts[:default]
+        @current_prompt_changed = false
     end
 
     def set_cards(card_list)
@@ -85,8 +86,11 @@ class CardDialog
     def draw
         if @visible
             @baground_image.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, 0.25, 0.25)
-            # @font.draw_text(@prompt, @dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
-            @current_prompt_image.draw(@dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
+            if @current_prompt_changed
+                @current_prompt_image.draw(@dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
+            else
+                @font.draw_text(@prompt, @dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
+            end
             @card_buttons.each do |card_button|
                 card_button.draw
             end
@@ -119,8 +123,15 @@ class CardDialog
         @selected_card = nil
     end
 
-    def set_prompt(text)
+    def set_prompt(text, prompt_key=:default)
+        should_change_current_prompt  = prompt_key != :default
+        if should_change_current_prompt
+            @current_prompt_image = @dialog_prompts[prompt_key]
+            @current_prompt_changed = true
+            return
+        end
         @prompt = text
+        @current_prompt_changed = false
     end
 
     def handle_result

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -65,6 +65,7 @@ class CardDialog
         @dialog_content_y_position = @dialog_y_position + @boarder_width
         @item_spacing = 10
         @dialog_prompts = dialog_prompts
+        @current_prompt_image = dialog_prompts[:default]
     end
 
     def set_cards(card_list)
@@ -84,7 +85,8 @@ class CardDialog
     def draw
         if @visible
             @baground_image.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, 0.25, 0.25)
-            @font.draw_text(@prompt, @dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
+            # @font.draw_text(@prompt, @dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
+            @current_prompt_image.draw(@dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
             @card_buttons.each do |card_button|
                 card_button.draw
             end

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -74,6 +74,7 @@ class CardDialog
         @card_buttons = []
         cardsDisplayed = 1 # accounts for prompt
         card_list.each do |card|
+            #TODO:: need to generate these statically
             @card_buttons << Button.new(@window, "#{card}",
                                 @dialog_content_x_position,
                                 @dialog_content_y_position + @item_spacing * cardsDisplayed + @font.height * cardsDisplayed,

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -123,7 +123,7 @@ class CardDialog
         @selected_card = nil
     end
 
-    def set_prompt(text, prompt_key=:default)
+    def set_prompt(text, prompt_key)
         should_change_current_prompt  = prompt_key != :default
         if should_change_current_prompt
             @current_prompt_image = @dialog_prompts[prompt_key]

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -32,5 +32,32 @@ describe "CardDialog" do
             # execute
             sut.draw
         end
+
+        it "should not call draw_text on font when prompt symbol is passed" do
+            # setup
+            gui_double = double("gui")
+            background_double = double("background", draw: nil)
+            font_double = instance_double("font")
+            input_stream = StringIO.new("")
+            test_logger = TestLogger.new(input_stream, test_outfile)
+            prompt_image_double = double("prompt image", draw: nil)
+            expected_prompt_key = :some_expected_prompt
+            sut = CardDialog.new(
+                gui_double,
+                background_double,
+                font_double,
+                test_logger,
+                {expected_prompt_key => prompt_image_double})
+
+            # setup lite
+            sut.set_prompt(expected_prompt_key)
+            sut.show
+
+            # set expectations (Assertaions, Test) first
+            expect(font_double).not_to receive(:draw_text).with(any_args)
+
+            # execute
+            sut.draw
+        end
     end
 end

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -13,12 +13,13 @@ describe "CardDialog" do
             background_double = double("background", draw: nil)
             font_double = instance_double("font", draw_text: nil)
             input_stream = StringIO.new("")
-            test_logger = TestLogger.new(input_stream, $stdout)
+            test_logger = TestLogger.new(input_stream, test_outfile)
             sut = CardDialog.new(
                 gui_double,
                 background_double,
                 font_double,
-                test_logger)
+                test_logger,
+                {})
             expected_prompt_text = "Some prompt text"
 
             # setup lite


### PR DESCRIPTION
This code is purely additive and currently unused, making this feature a "dark release". Once all prompting is converted to use static prompts then this code should be cleaned up and simplified accordingly. 

_Note: since this now depends on #34 a more accurate diff can be seen [here](https://github.com/jjm3x3/flux/compare/feature/inject-all-gosu-objects-into-dialog...feature/enable-static-prompt-use-in-gui-dialog)_