### PR TITLE
Feature/inject prompt strings into gui

### DIFF
--- a/game_gui.rb
+++ b/game_gui.rb
@@ -31,7 +31,8 @@ class GameGui < Gosu::Window
             Gosu::Image.new("assets/onlineGreenSquare2.png", tileable: true),
             Gosu::Font.new(20),
             logger,
-            initialize_dialog_prompts)
+            initialize_dialog_prompts(prompt_strings))
+
         @new_game_driver = nil
 
         @current_cached_player = nil
@@ -40,8 +41,13 @@ class GameGui < Gosu::Window
         @play_card_future = nil
     end
 
-    def initialize_dialog_prompts
-        return {default: Gosu::Image.from_text("Some default prompt", 20), discard_down_to_limit: Gosu::Image.from_text("Player playerX Select a card to discard", 20)}
+    def initialize_dialog_prompts(prompt_strings)
+        result = {}
+        prompt_strings.map do |key, prompt_string|
+            result[key] = Gosu::Image.from_text(prompt_string, 20)
+        end
+
+        return result
     end
 
     def button_up(id)

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -7,7 +7,7 @@ require './gui_input_manager.rb'
 require './game_driver.rb'
 
 class GameGui < Gosu::Window
-    def initialize(logger)
+    def initialize(logger, prompt_strings)
         super 640, 960
         self.caption = "Fluxx"
 

--- a/main.rb
+++ b/main.rb
@@ -21,9 +21,16 @@ end
 
 puts "starting game where debug: #{debug} and gui: #{gui}"
 
+
+prompt_strings = {
+  default: "Some default prompt",
+  play_first_prompt: "Which one would you like to play first?",
+  select_a_card_to_play_prompt: "Select a card from your hand to play"
+}
+
 logger = CliLogger.new(debug)
 if gui
-  guiGame = GameGui.new(logger)
+  guiGame = GameGui.new(logger, prompt_strings)
   guiGame.show
 else
   players = Player.generate_players(3)


### PR DESCRIPTION
Here is a diff to inject some strings into the gui, just as the name suggests. This will technically make it so the gui are out of sync feature wise, but since none of these prompts are currently exercised all will continue to work as normal. Next stop setup cli to accept these static prompts. For a diff against the dependent branch take a look [here](https://github.com/jjm3x3/flux/compare/feature/enable-static-prompt-use-in-gui-dialog...feature/inject-prompt-strings-into-gui).