### PR TITLE
Bugfix/dont block draw

### DIFF
--- a/deck.rb
+++ b/deck.rb
@@ -23,7 +23,8 @@ class Deck
     #   # newInjectedCard = Action.new(16,"extra exchange keepers", "put some rule text here")
     #   # newInjectedCard = Limit.new("no keepers", 4, "put some rule text here", 0)
     #   newInjectedCard = Creeper.new(1, "wanna be war", "Some rule text")
-    #   drawnCards = [newInjectedCard]
+    #   newInjectedCard2 = Creeper.new(3, "wanna be death", "Some rule text")
+    #   drawnCards = [newInjectedCard, newInjectedCard2]
     #   drawnCards << Keeper.new(16, "pease")
     #   cardsToDraw -= 1
     # end

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -123,6 +123,15 @@ class GameGui < Gosu::Window
             @left_click_down = true
 
         end
+
+        if @new_game_driver && @player_changed
+            new_turn_future = @new_game_driver.async.setup_new_turn
+            new_turn_future.add_observer do |time, value|
+                @redraw_hand = true
+
+                @player_changed = false
+            end
+        end
     end
 
     def needs_cursor?
@@ -174,18 +183,6 @@ class GameGui < Gosu::Window
 
                 @redraw_hand = false
 
-                if @player_changed
-                    # TODO:: Make sure not to await anything here
-                    #
-                    #       after thinking more about this we can repro a bug
-                    #       by making sure the first player starts the game with
-                    #       two creepeprs one of them death
-                    #
-                    @new_game_driver.await.setup_new_turn
-                    @redraw_hand = true
-
-                    @player_changed = false
-                end
             else
                 @current_displayed_cards.each do |cardButton|
                     cardButton.draw


### PR DESCRIPTION
## TL;DR don't call async code in draw.

The Draw method is most crucial to the entire gui continuing to work, even if things on the back-end have gone off the rails _(nice pun)_. The fix to this is simple. Don't call any async methods/classes in the draw method. After making this change there is only one reference to an async class [here](https://github.com/jjm3x3/flux/blob/62d47eef4babd0383d393cacb85eb8557a46bc8b/game_gui.rb#L148), and it only exists to check existence. I have also updated the deck stacking though commented out as always to demonstrate the issue.

## Repro steps:
1. Uncomment card injecting code
1. Start game like `./main.rb --gui --debug` 
1. Click to start a new game
1. Watch game brick 