### PR TITLE
Bugfix/set player changed immediately

### DIFF
--- a/game_gui.rb
+++ b/game_gui.rb
@@ -125,6 +125,7 @@ class GameGui < Gosu::Window
         end
 
         if @new_game_driver && @player_changed
+            @logger.debug "GameGui::update Player has changed setting up new turn"
             new_turn_future = @new_game_driver.async.setup_new_turn
             new_turn_future.add_observer do |time, value|
                 @redraw_hand = true

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -126,11 +126,11 @@ class GameGui < Gosu::Window
 
         if @new_game_driver && @player_changed
             @logger.debug "GameGui::update Player has changed setting up new turn"
+            @player_changed = false
             new_turn_future = @new_game_driver.async.setup_new_turn
             new_turn_future.add_observer do |time, value|
                 @redraw_hand = true
 
-                @player_changed = false
             end
         end
     end


### PR DESCRIPTION
Here is a very small subtle bug. Also this diff is based off of #38 so to get a more accurate diff view check [here](https://github.com/jjm3x3/flux/compare/bugfix/dont-block-draw...bugfix/set-player-changed-immediately)

## Repro steps:
1. Uncomment card injecting code
1. Start game like `./main.rb --gui --debug` 
1. Click to start a new game
1. Watch debug logs.

## What is happening
So if you didn't have debug logs it would be a bit tricky to catch, hence the extra commit to add a debug log line. So while the death prompt "What card would you like to discard to death" is active and waiting for user input. The gui state flag to indicate the player has changed has not been reset to false. As a result of this the current player (which it turns out is the first player. Note this would normally be the next player, but since its the beginning of the game its just the first player) will continue to draw cards as if it is the beginning of their turn. resulting it depleting the deck and that player drawing cards they weren't supposed to.

## So whats the fix
As soon as the update block to setup a new turn gets triggered set the player changed gui state flag to false, then proceed to do new turn setup.