### PR TITLE
Feature/add addprompt method to card dialog

### DIFF
--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -69,6 +69,10 @@ class CardDialog
         @draw_prompt_image = false
     end
 
+    def add_prompt(symbol, prompt_image)
+        @dialog_prompts[symbol] = prompt_image
+    end
+
     def set_cards(card_list)
         @card_list = card_list
         @card_buttons = []

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -137,6 +137,7 @@ class CardDialog
         else
             @logger.debug "prompt is_a symb"
             @logger.debug "set_prompt: dialog_prompts contents: #{@dialog_prompts}"
+            if !@dialog_prompts.has_key? prompt; raise "prompt_key missing from prompts collection"; end
             @current_prompt_image = @dialog_prompts[prompt]
             @draw_prompt_image = true
         end

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -99,8 +99,8 @@ describe "CardDialog" do
                 {})
             expected_prompt_key = :some_prompt_key
 
-            # setup lite
-            # sut.add_prompt(expected_prompt_key, double("SomeGosuImage"))
+            # execute the test
+            sut.add_prompt(expected_prompt_key, double("SomeGosuImage"))
 
             # Assert this should not fail
             sut.set_prompt(expected_prompt_key)

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -60,6 +60,27 @@ describe "CardDialog" do
             sut.draw
         end
 
+        it "should raise an error if the prompt is a symbol which doesn't exist in the dialog_prompts" do
+            # setup
+            gui_double = double("gui")
+            background_double = double("background", draw: nil)
+            font_double = instance_double("font", draw_text: nil)
+            input_stream = StringIO.new("")
+            test_logger = TestLogger.new(input_stream, test_outfile)
+            sut = CardDialog.new(
+                gui_double,
+                background_double,
+                font_double,
+                test_logger,
+                {})
+            expected_prompt_key = :some_prompt_key
+
+            # Execute and Assert this should not fail
+            expect do
+                sut.set_prompt(expected_prompt_key)
+            end.to raise_error("prompt_key missing from prompts collection")
+        end
+
         it "should have an add_prompt method which will prevent set_prompt from raising an error" do
             # setup
             gui_double = double("gui")

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -59,5 +59,27 @@ describe "CardDialog" do
             # execute
             sut.draw
         end
+
+        it "should have an add_prompt method which will prevent set_prompt from raising an error" do
+            # setup
+            gui_double = double("gui")
+            background_double = double("background", draw: nil)
+            font_double = instance_double("font", draw_text: nil)
+            input_stream = StringIO.new("")
+            test_logger = TestLogger.new(input_stream, test_outfile)
+            sut = CardDialog.new(
+                gui_double,
+                background_double,
+                font_double,
+                test_logger,
+                {})
+            expected_prompt_key = :some_prompt_key
+
+            # setup lite
+            # sut.add_prompt(expected_prompt_key, double("SomeGosuImage"))
+
+            # Assert this should not fail
+            sut.set_prompt(expected_prompt_key)
+        end
     end
 end

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -81,7 +81,10 @@ describe "CardDialog" do
             end.to raise_error("prompt_key missing from prompts collection")
         end
 
-        it "should have an add_prompt method which will prevent set_prompt from raising an error" do
+    end
+
+    describe "add_prompt" do
+        it "should exist to prevent set_prompt from raising an error" do
             # setup
             gui_double = double("gui")
             background_double = double("background", draw: nil)


### PR DESCRIPTION
Just as the name suggests. This method could not be more simple. As for testing, it would be nice to test this, but there isn't much to test here since this is internal state. Having said that I did at least add a single test which will assert that this method exists and check for side effects. While adding this test I found another small little change that would be good to have so I added a test for that and a small piece of code to address the behavior. 

_Note: Of course this is based on #40 so to get a better diff check out [this](https://github.com/jjm3x3/flux/compare/feature/update-card-logic-to-use-prompt-keys...feature/add-addprompt-method-to-card-dialog)_