### PR TITLE
Feature/add a playerpromptgenerator

### DIFF
--- a/constants/prompts.rb
+++ b/constants/prompts.rb
@@ -1,23 +1,23 @@
 module Constants
     PROMPT_STRINGS = {
         default: "Some default prompt",
-        play_first_prompt: "Which one would you like to play first?",
-        select_a_card_to_play_prompt: "Select a card from your hand to play",
-        discard_down_to_keeper_limit: "Choose a keeper to discard",
-        play_next_prompt: "which would you like to play next?",
-        which_player_to_pick_from_prompt: "which player would you like to pick from",
-        choose_card_to_play_prompt: "pick a card to play",
-        birthday_prompt: "is today your birthday",
-        holiday_anniversary_prompt: "Is today a holiday or an anniversary",
-        replay_prompt: "pick a card you would like to replay",
-        give_card_to_yourself_prompt: "which card would you like to giver to yourself",
-        trade_hands_prompt: "who would you like to trade hands with?",
-        rotation_prompt: "Which way would you like to rotate?",
-        pick_a_keeper_from_prompt: "Which player would you like to take a keeper from",
         are_you_sure_no_trade_prompt: "Are you sure you don't want to trade with anyone?",
-        select_a_keeper_prompt: "Slect which Keeper you would like",
+        birthday_prompt: "is today your birthday",
+        choose_card_to_play_prompt: "pick a card to play",
+        death_discard_prompt: "Which permanent would you like to discard to death?",
+        discard_down_to_keeper_limit: "Choose a keeper to discard",
+        give_card_to_yourself_prompt: "which card would you like to giver to yourself",
+        holiday_anniversary_prompt: "Is today a holiday or an anniversary",
         keeper_to_give_prompt: "Which player would you like to take a keeper from",
-        death_discard_prompt: "Which permanent would you like to discard to death?"
+        pick_a_keeper_from_prompt: "Which player would you like to take a keeper from",
+        play_first_prompt: "Which one would you like to play first?",
+        play_next_prompt: "which would you like to play next?",
+        replay_prompt: "pick a card you would like to replay",
+        rotation_prompt: "Which way would you like to rotate?",
+        select_a_card_to_play_prompt: "Select a card from your hand to play",
+        select_a_keeper_prompt: "Slect which Keeper you would like",
+        trade_hands_prompt: "who would you like to trade hands with?",
+        which_player_to_pick_from_prompt: "which player would you like to pick from",
     }
 
     USER_SPECIFIC_PROMPTS = {

--- a/constants/prompts.rb
+++ b/constants/prompts.rb
@@ -20,4 +20,10 @@ module Constants
         keeper_to_give_prompt: "Which player would you like to take a keeper from",
         death_discard_prompt: "Which permanent would you like to discard to death?"
     }
+
+    USER_SPECIFIC_PROMPTS = {
+      discard_prompt_name: {
+          key_template: "discard_down_to_limit_{name}",
+          value_template: "Player {name} Select a card to discard"}
+    }
 end

--- a/constants/prompts.rb
+++ b/constants/prompts.rb
@@ -6,7 +6,6 @@ module Constants
         discard_down_to_keeper_limit: "Choose a keeper to discard",
         play_next_prompt: "which would you like to play next?",
         which_player_to_pick_from_prompt: "which player would you like to pick from",
-        discard_down_to_limit: "Player player2 Select a card to discard",
         choose_card_to_play_prompt: "pick a card to play",
         birthday_prompt: "is today your birthday",
         holiday_anniversary_prompt: "Is today a holiday or an anniversary",

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -7,7 +7,7 @@ require './gui_input_manager.rb'
 require './game_driver.rb'
 
 class GameGui < Gosu::Window
-    def initialize(logger, prompt_strings)
+    def initialize(logger, prompt_strings, user_prompt_templates)
         super 640, 960
         self.caption = "Fluxx"
 
@@ -26,6 +26,7 @@ class GameGui < Gosu::Window
         @logger = logger
 
         @are_you_sure_dialog = Dialog.new(self)
+
         @current_dialog = CardDialog.new(
             self,
             Gosu::Image.new("assets/onlineGreenSquare2.png", tileable: true),
@@ -33,6 +34,7 @@ class GameGui < Gosu::Window
             logger,
             initialize_dialog_prompts(prompt_strings))
 
+        @user_prompt_templates = user_prompt_templates
         @new_game_driver = nil
 
         @current_cached_player = nil

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -71,6 +71,9 @@ class GameGui < Gosu::Window
                         puts "I am starting a game then"
                         numberOfPlayers = 3
                         players = Player.generate_players(numberOfPlayers)
+                        PlayerPromptGenerator.generate_prompts(players, @user_prompt_templates).each do |key, prompt|
+                            @current_dialog.add_prompt(key, Gosu::Image.from_text(prompt, 20))
+                        end
                         @game = Game.new(@logger, GuiInputManager.new(self), players)
                         @game.setup
                         @new_game_driver = GameDriver.new(@game, @logger)

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -136,7 +136,7 @@ class CardDialog
             @draw_prompt_image = false
         else
             @logger.debug "prompt is_a symb"
-            @logger.debug "set_prompt: dialog_prompts contents: #{@dialog_prompts}"
+            @logger.trace "set_prompt: dialog_prompts contents: #{@dialog_prompts}"
             if !@dialog_prompts.has_key? prompt; raise "prompt_key missing from prompts collection"; end
             @current_prompt_image = @dialog_prompts[prompt]
             @draw_prompt_image = true

--- a/main.rb
+++ b/main.rb
@@ -23,19 +23,13 @@ end
 puts "starting game where debug: #{debug} and gui: #{gui}"
 
 
-user_specific_prompts = {
-  discard_prompt_name: {
-      key_template: "discard_down_to_limit_{name}",
-      value_template: "Player {name} Select a card to discard"}
-}
-
 logger = CliLogger.new(debug)
 if gui
-  guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, user_specific_prompts)
+  guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS)
   guiGame.show
 else
   players = Player.generate_players(3)
-  player_prompts = PlayerPromptGenerator.generate_prompts(players, user_specific_prompts)
+  player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
   prompt_strings = Constants::PROMPT_STRINGS.merge(player_prompts)
   cli_interface = CliInterface.new(prompt_strings)
   theGame = Game.new(logger, cli_interface, players)

--- a/main.rb
+++ b/main.rb
@@ -23,6 +23,12 @@ end
 puts "starting game where debug: #{debug} and gui: #{gui}"
 
 
+user_specific_prompts = {
+  discard_prompt_name: {
+      key_template: "discard_down_to_limit_{name}",
+      value_template: "Player {name} Select a card to discard"}
+}
+
 logger = CliLogger.new(debug)
 if gui
   guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS)

--- a/main.rb
+++ b/main.rb
@@ -35,7 +35,9 @@ if gui
   guiGame.show
 else
   players = Player.generate_players(3)
-  cli_interface = CliInterface.new(Constants::PROMPT_STRINGS)
+  player_prompts = PlayerPromptGenerator.generate_prompts(players, user_specific_prompts)
+  prompt_strings = Constants::PROMPT_STRINGS.merge(player_prompts)
+  cli_interface = CliInterface.new(prompt_strings)
   theGame = Game.new(logger, cli_interface, players)
   theGame.setup
   gameDriver = GameCli.new(theGame, logger, GameDriver.new(theGame, logger), cli_interface)

--- a/main.rb
+++ b/main.rb
@@ -31,7 +31,7 @@ user_specific_prompts = {
 
 logger = CliLogger.new(debug)
 if gui
-  guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS)
+  guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, user_specific_prompts)
   guiGame.show
 else
   players = Player.generate_players(3)

--- a/player.rb
+++ b/player.rb
@@ -1,3 +1,9 @@
+class PlayerPromptGenerator
+  def self.generate_prompts(players, prompt_templates)
+    result = {}
+    return result
+  end
+end
 
 class Player
   attr_reader :creepers, :name, :keepers, :hand

--- a/player.rb
+++ b/player.rb
@@ -8,6 +8,9 @@ class PlayerPromptGenerator
         key = prompt_hash[:key_template].gsub(/{name}/, player.name).to_sym
         prompt = prompt_hash[:value_template].gsub(/{name}/, player.name)
         result[key] = prompt
+        player.define_singleton_method(prompt_name.to_sym) do
+          return key
+        end
       end
     end
     return result

--- a/player.rb
+++ b/player.rb
@@ -4,7 +4,6 @@ class PlayerPromptGenerator
     players.each do |player|
 
       prompt_templates.each do |prompt_name, prompt_hash|
-        puts prompt_hash
         key = prompt_hash[:key_template].gsub(/{name}/, player.name).to_sym
         prompt = prompt_hash[:value_template].gsub(/{name}/, player.name)
         result[key] = prompt

--- a/player.rb
+++ b/player.rb
@@ -1,6 +1,15 @@
 class PlayerPromptGenerator
   def self.generate_prompts(players, prompt_templates)
     result = {}
+    players.each do |player|
+
+      prompt_templates.each do |prompt_name, prompt_hash|
+        puts prompt_hash
+        key = prompt_hash[:key_template].gsub(/{name}/, player.name).to_sym
+        prompt = prompt_hash[:value_template].gsub(/{name}/, player.name)
+        result[key] = prompt
+      end
+    end
     return result
   end
 end

--- a/tests/player_spec.rb
+++ b/tests/player_spec.rb
@@ -1,6 +1,24 @@
 require "tempfile"
 require "./game.rb"
 
+describe "PlayerPromptGenerator" do
+    describe "generate_prompts" do
+
+        user_specific_prompts = {
+          some_prompt_name: {
+              key_template: "some_key",
+              value_template: "some_value"}
+        }
+
+        it "should generate a prompt per uesr" do
+            players = Player.generate_players(2)
+            result = PlayerPromptGenerator.generate_prompts(players, user_specific_prompts)
+            expect(result.size).to eq 2 # there should be two prompts one for each player
+        end
+
+    end
+end
+
 describe "player" do
 
     test_outfile = Tempfile.new 'test_output'

--- a/tests/player_spec.rb
+++ b/tests/player_spec.rb
@@ -16,6 +16,16 @@ describe "PlayerPromptGenerator" do
             expect(result.size).to eq 2 # there should be two prompts one for each player
         end
 
+        it "should add a property to the user in order to recal the prompt" do
+            players = Player.generate_players(2)
+            result = PlayerPromptGenerator.generate_prompts(players, user_specific_prompts)
+
+            players.each do |player|
+                user_specific_prompts.each do |key, value|
+                    expect(player.respond_to?(key.to_sym)).to be true
+                end
+            end
+        end
     end
 end
 

--- a/tests/player_spec.rb
+++ b/tests/player_spec.rb
@@ -6,8 +6,8 @@ describe "PlayerPromptGenerator" do
 
         user_specific_prompts = {
           some_prompt_name: {
-              key_template: "some_key",
-              value_template: "some_value"}
+              key_template: "Some_key_name_{name}",
+              value_template: "Some prompt where a name like: '{name}' belongs"}
         }
 
         it "should generate a prompt per uesr" do


### PR DESCRIPTION
Because there is no guarantee that we know the how many players there are or what their names are when the game is startup we can not hard code these prompts they can only be generated once we know how many players and what their names are. As a result we can templatize the prompts but we will still need to generate individual prompts once we know these things. 

This is a part of an ongoing effort to make sure that Prompts and Gosu assets are created as early in the games lifecycle as possible. As a purely TUI/CLI based game this was not an issue, but based on how the Gosu drawing and updating loop works, we need to know about these things as early as possible.