### PR TITLE
Feature/add more failed async handling

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -324,7 +324,11 @@ class Game
       @logger.debug "Game::everbody_gets_1: Number of cards left to deal out: #{cardsDrawn.length}"
       player_to_select_card_for = @players[playerCur]
       if playerCur == currentPlayer
-        selectedCard = @interface.await.choose_from_list(cardsDrawn, "which card would you like to giver to yourself").value
+        choose_result = @interface.await.choose_from_list(cardsDrawn, "which card would you like to giver to yourself")
+        if choose_result.state != :fulfilled
+          @logger.warn  "choose_result may not have been fulfilled because #{choose_result.reason}"
+        end
+        selectedCard = choose_result.value
       else
         selectedCard = @interface.await.choose_from_list(cardsDrawn, "which card would you like to give to #{@players[playerCur]}").value
       end

--- a/game.rb
+++ b/game.rb
@@ -203,7 +203,7 @@ class Game
     @logger.debug "Going to select a second one"
     second_choice_result = @interface.await.choose_from_list(cardsDrawn, :play_next_prompt)
     if second_choice_result.state != :fulfilled
-      @logger.debug "second_choice_result may not have been fulfilled because: '#{second_choice_result.reason}'"
+      @logger.warn "second_choice_result may not have been fulfilled because: '#{second_choice_result.reason}'"
     end
     second_choice_result.value.play(player, self)
     discard(cardsDrawn[0])

--- a/game.rb
+++ b/game.rb
@@ -321,12 +321,15 @@ class Game
     cardsDrawn = drawCards(player, @players.length)
     playerCur = currentPlayer
     while cardsDrawn.length > 0
+      @logger.debug "Game::everbody_gets_1: Number of cards left to deal out: #{cardsDrawn.length}"
+      player_to_select_card_for = @players[playerCur]
       if playerCur == currentPlayer
         selectedCard = @interface.await.choose_from_list(cardsDrawn, "which card would you like to giver to yourself").value
       else
         selectedCard = @interface.await.choose_from_list(cardsDrawn, "which card would you like to give to #{@players[playerCur]}").value
       end
-      @players[playerCur].hand << selectedCard
+      @logger.debug "Game::everbody_gets_1: Player #{player_to_select_card_for.to_s} has a hand of length: #{player_to_select_card_for.hand.length}}"
+      player_to_select_card_for.hand << selectedCard
       playerCur += 1
       playerCur %= @players.length
     end

--- a/game.rb
+++ b/game.rb
@@ -201,8 +201,11 @@ class Game
     @logger.debug "Here is the first card that was selected #{firstOne.value}"
     firstOne.value.play(player, self)
     @logger.debug "Going to select a second one"
-    secondOne = @interface.await.choose_from_list(cardsDrawn, :play_next_prompt)
-    secondOne.value.play(player, self)
+    second_choice_result = @interface.await.choose_from_list(cardsDrawn, :play_next_prompt)
+    if second_choice_result.state != :fulfilled
+      @logger.debug "second_choice_result may not have been fulfilled because: '#{second_choice_result.reason}'"
+    end
+    second_choice_result.value.play(player, self)
     discard(cardsDrawn[0])
   end
 

--- a/game_cli.rb
+++ b/game_cli.rb
@@ -24,7 +24,7 @@ class GameCli
           play_result = @new_game_driver.await.post_card_play_clean_up(activePlayer, cardToPlay)
           @logger.debug "What was the play result? '#{play_result.state}'"
           if play_result.state != :fulfilled
-            @logger.debug "play_result may not have been fulfilled because: '#{play_result.reason}'"
+            @logger.warn "play_result may not have been fulfilled because: '#{play_result.reason}'"
           end
           cardsPlayed += 1
 

--- a/game_cli.rb
+++ b/game_cli.rb
@@ -23,6 +23,9 @@ class GameCli
 
           play_result = @new_game_driver.await.post_card_play_clean_up(activePlayer, cardToPlay)
           @logger.debug "What was the play result? '#{play_result.state}'"
+          if play_result.state != :fulfilled
+            @logger.debug "play_result may not have been fulfilled because: '#{play_result.reason}'"
+          end
           cardsPlayed += 1
 
           hand = activePlayer.hand # really a sad sideeffect of much statefull programming

--- a/logger.rb
+++ b/logger.rb
@@ -28,6 +28,10 @@ class BaseLogger
     @output_stream.puts message
   end
 
+  def warn(message)
+    @output_stream.puts message
+  end
+
   def log_cards(hand,prompt="Here is your current hand:")
     debug "#{prompt}\n#{StringFormattingUtilities.indexed_display(hand)}"
   end


### PR DESCRIPTION
Here is some more post-facto adding of async error handling. As the scope of what happens in async threads increases there are that many more things that can go wrong. In order to catch those things earlier and understand what the failure was, as opposed to swallowing it, we need to log the errors as soon as they happen. I am going to start doing that at "warn" level since for one I intend to bring in the standard ruby `Logger` and also these need to be logged at a level higher than Info (possibly even error, but I'm going to leave it at warn for now)