### PR TITLE
Feature/use player specific prompt keys

### DIFF
--- a/constants/prompts.rb
+++ b/constants/prompts.rb
@@ -25,7 +25,7 @@ module Constants
             key_template: "discard_down_to_limit_{name}",
             value_template: "Player {name} Select a card to discard"
         },
-        taxation_prompt_name: {
+        give_card_to_player_prompt_name: {
             key_template: "give_card_to_player_{name}",
             value_template: "Choose a card to give to {name}"
         }

--- a/constants/prompts.rb
+++ b/constants/prompts.rb
@@ -28,6 +28,10 @@ module Constants
         give_card_to_player_prompt_name: {
             key_template: "give_card_to_player_{name}",
             value_template: "Choose a card to give to {name}"
+        },
+        move_war_prompt_name: {
+            key_template: "{name}_move_war_prompt",
+            value_template: "{name} since you have peace. Who would you like to give war to?"
         }
     }
 end

--- a/constants/prompts.rb
+++ b/constants/prompts.rb
@@ -21,8 +21,13 @@ module Constants
     }
 
     USER_SPECIFIC_PROMPTS = {
-      discard_prompt_name: {
-          key_template: "discard_down_to_limit_{name}",
-          value_template: "Player {name} Select a card to discard"}
+        discard_prompt_name: {
+            key_template: "discard_down_to_limit_{name}",
+            value_template: "Player {name} Select a card to discard"
+        },
+        taxation_prompt_name: {
+            key_template: "give_card_to_player_{name}",
+            value_template: "Choose a card to give to {name}"
+        }
     }
 end

--- a/game.rb
+++ b/game.rb
@@ -468,7 +468,7 @@ class Game
     playerHasPeace = player.has_peace?
     playerHasWar = player.has_war?
     if (playerHasPeace && playerHasWar)
-      selectedPlayer = @interface.await.choose_from_list(opponents(player), "#{player} since you have peace. Who would you like to give war too?").value
+      selectedPlayer = @interface.await.choose_from_list(opponents(player), player.move_war_prompt_name).value
       @logger.debug "Who is the selected playar #{selectedPlayer}\n who is the original #{player}"
 
       selectedPlayer.add_creeper(player.take_war)

--- a/game.rb
+++ b/game.rb
@@ -236,7 +236,8 @@ class Game
     newCardsForPlayer = opponents(player).select do |player|
       player.hand.size > 0
     end.map do |aPlayer|
-      @interface.await.choose_from_list(aPlayer.hand, player.taxation_prompt_name).value
+      @logger.debug "prompting #{aPlayer} to give a card to #{player}"
+      @interface.await.choose_from_list(aPlayer.hand, player.give_card_to_player_prompt_name).value
     end
     player.add_cards_to_hand(newCardsForPlayer)
   end

--- a/game.rb
+++ b/game.rb
@@ -327,13 +327,13 @@ class Game
       @logger.debug "Game::everbody_gets_1: Number of cards left to deal out: #{cardsDrawn.length}"
       player_to_select_card_for = @players[playerCur]
       if playerCur == currentPlayer
-        choose_result = @interface.await.choose_from_list(cardsDrawn, "which card would you like to giver to yourself")
+        choose_result = @interface.await.choose_from_list(cardsDrawn, :give_card_to_yourself_prompt)
         if choose_result.state != :fulfilled
           @logger.warn  "choose_result may not have been fulfilled because #{choose_result.reason}"
         end
         selectedCard = choose_result.value
       else
-        selectedCard = @interface.await.choose_from_list(cardsDrawn, "which card would you like to give to #{@players[playerCur]}").value
+        selectedCard = @interface.await.choose_from_list(cardsDrawn, player_to_select_card_for.give_card_to_player_prompt_name).value
       end
       @logger.debug "Game::everbody_gets_1: Player #{player_to_select_card_for.to_s} has a hand of length: #{player_to_select_card_for.hand.length}}"
       player_to_select_card_for.hand << selectedCard

--- a/game.rb
+++ b/game.rb
@@ -236,7 +236,7 @@ class Game
     newCardsForPlayer = opponents(player).select do |player|
       player.hand.size > 0
     end.map do |aPlayer|
-      @interface.await.choose_from_list(aPlayer.hand, "Choose a card to give to #{player}").value
+      @interface.await.choose_from_list(aPlayer.hand, player.taxation_prompt_name).value
     end
     player.add_cards_to_hand(newCardsForPlayer)
   end

--- a/game.rb
+++ b/game.rb
@@ -96,7 +96,7 @@ class Game
   def discardDownToLimit(player)
     @logger.debug "The hand limit is #{@ruleBase.handLimit}"
     while player.hand.count > @ruleBase.handLimit
-      removed_card_result = @interface.await.choose_from_list(player.hand, "Player #{player} Select a card to discard")
+      removed_card_result = @interface.await.choose_from_list(player.hand, player.discard_prompt_name)
       @logger.debug "Game::discardDownToLimit: What state is the removed_card_result: #{removed_card_result.state}"
       if removed_card_result.state != :fulfilled
         @logger.info "choose_result may not have been fulfilled because #{removed_card_result.reason}"

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -72,6 +72,7 @@ class GameGui < Gosu::Window
                         numberOfPlayers = 3
                         players = Player.generate_players(numberOfPlayers)
                         PlayerPromptGenerator.generate_prompts(players, @user_prompt_templates).each do |key, prompt|
+                            # TODO:: should check to make sure @current_dialog exists
                             @current_dialog.add_prompt(key, Gosu::Image.from_text(prompt, 20))
                         end
                         @game = Game.new(@logger, GuiInputManager.new(self), players)

--- a/tests/game_spec.rb
+++ b/tests/game_spec.rb
@@ -710,8 +710,9 @@ describe "game" do
             input_stream = StringIO.new("0\n0\n0\n")
             testLogger = Logger.new(test_outfile)
             numberOfPlayers = 3
-            testInterface = TestInterface.new(input_stream, test_outfile)
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
             theGame = Game.new(testLogger, testInterface, players)
             theGame.setup
             theFirstPlayer = theGame.players[0]
@@ -729,8 +730,9 @@ describe "game" do
             input_stream = StringIO.new("0\n0\n0\n")
             testLogger = Logger.new(test_outfile)
             numberOfPlayers = 3
-            testInterface = TestInterface.new(input_stream, test_outfile)
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
             theGame = Game.new(testLogger, testInterface, players)
             theGame.setup
             theFirstPlayer = theGame.players[0]

--- a/tests/game_spec.rb
+++ b/tests/game_spec.rb
@@ -983,8 +983,9 @@ describe "game" do
             numberOfPlayers = 4
             input_stream = StringIO.new("0\n" * numberOfPlayers)
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile)
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
             theGame = Game.new(testLogger, testInterface, players)
             theFirstPlayer = theGame.players[0]
             theGame.deck = StackedDeck.new(testLogger, cardsToPutOnTop=[], startEmpty=false, withCreepers=false)
@@ -1002,8 +1003,9 @@ describe "game" do
             numberOfPlayers = 4
             input_stream = StringIO.new("0\n" * numberOfPlayers)
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile)
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, Constants::PROMPT_STRINGS.merge(player_prompts))
             theGame = Game.new(testLogger, testInterface, players)
             theFirstPlayer = theGame.players[0]
             originalDeckCount = theGame.deck.count
@@ -1022,8 +1024,9 @@ describe "game" do
             numberOfPlayers = 4
             input_stream = StringIO.new("0\n" * numberOfPlayers)
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile)
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
             theGame = Game.new(testLogger, testInterface, players)
             theFirstPlayer = theGame.players[0]
             theGame.currentPlayerCounter = 8
@@ -1040,8 +1043,9 @@ describe "game" do
             numberOfPlayers = 4
             input_stream = StringIO.new("0\n" * numberOfPlayers)
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile)
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
             theGame = Game.new(testLogger, testInterface, players)
             theFirstPlayer = theGame.players[0]
             theGame.currentPlayerCounter = 9
@@ -1058,8 +1062,9 @@ describe "game" do
             numberOfPlayers = 3
             input_stream = StringIO.new("0\n" * numberOfPlayers)
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile)
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
             theGame = Game.new(testLogger, testInterface, players)
             warCreeper = Creeper.new(1, "War", "with some rules text")
             theGame.deck = StackedDeck.new(testLogger, [warCreeper])
@@ -1078,8 +1083,9 @@ describe "game" do
             numberOfPlayers = 3
             input_stream = StringIO.new("0\n" * numberOfPlayers)
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile)
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
             theGame = Game.new(testLogger, testInterface, players)
             stackedCreepers = [Creeper.new(1, "War", "with some rules text")]
             theGame.deck = StackedDeck.new(testLogger, stackedCreepers)

--- a/tests/game_spec.rb
+++ b/tests/game_spec.rb
@@ -1550,9 +1550,10 @@ describe "game" do
             # setup
             input_stream = StringIO.new("1\n0\n")
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile, Constants::PROMPT_STRINGS)
             numberOfPlayers = 3
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, Constants::PROMPT_STRINGS.merge(player_prompts))
             theGame = Game.new(testLogger, testInterface, players)
             theFirstPlayer = theGame.players[0]
             catKeeper = Keeper.new(1000, "Cat")
@@ -1574,9 +1575,10 @@ describe "game" do
             # setup
             input_stream = StringIO.new("1\n0\n")
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile, Constants::PROMPT_STRINGS)
             numberOfPlayers = 3
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, Constants::PROMPT_STRINGS.merge(player_prompts))
             theGame = Game.new(testLogger, testInterface, players)
             theFirstPlayer = theGame.players[0]
             catKeeper = Keeper.new(1000, "Cat")
@@ -1600,9 +1602,10 @@ describe "game" do
             # setup
             input_stream = StringIO.new("0\n")
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile)
             numberOfPlayers = 3
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
             theGame = Game.new(testLogger, testInterface, players)
             theFirstPlayer = theGame.players[0]
             theFirstPlayer.keepers << Keeper.new(16, "wanna be peace")
@@ -1620,9 +1623,10 @@ describe "game" do
             # setup
             input_stream = StringIO.new("0\n")
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile)
             numberOfPlayers = 3
             players = Player.generate_players(numberOfPlayers)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
             theGame = Game.new(testLogger, testInterface, players)
             theFirstPlayer = theGame.players[0]
             theFirstPlayer.keepers << Keeper.new(16, "wanna be peace")

--- a/tests/game_spec.rb
+++ b/tests/game_spec.rb
@@ -160,8 +160,9 @@ describe "game" do
             # setup
             input_stream = StringIO.new("0\n")
             testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile, Constants::PROMPT_STRINGS)
             players = Player.generate_players(3)
+            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
+            testInterface = TestInterface.new(input_stream, test_outfile, Constants::PROMPT_STRINGS.merge(player_prompts))
             theGame = Game.new(testLogger, testInterface, players)
             theGame.setup
             theFirstPlayer = theGame.players[0]


### PR DESCRIPTION
Since the ground work was laid for this in the diff its based off of there isn't too much to describe here, just doing the remaining work so there are no more prompts that are created on the fly everything is created as soon as it can be (as a new game is created.)

_Note: this is based on #43 so it will be opened in draft mode until that gets merged. Until then you can view the effective diff [here](https://github.com/jjm3x3/flux/compare/feature/add-a-playerpromptgenerator...feature/use-player-specific-prompt-keys)_