### PR TITLE
Feature/inject decks

### DIFF
--- a/constants/stacked_decks.rb
+++ b/constants/stacked_decks.rb
@@ -19,4 +19,10 @@ module StackedDecks
             Goal.new("one and two", [keeper1, keeper2], "Have keeper1 & keeper2"),
             Rule.new("Play forever", 2, "XXXXXa"),
         ]
+
+    DISCARD_TO_DEATH_ON_FIRST_TURN =
+    [
+        Creeper.new(3, "extra death", "some rules text"),
+        Creeper.new(2, "extra taxes", "some rules text"),
+    ]
 end

--- a/constants/stacked_decks.rb
+++ b/constants/stacked_decks.rb
@@ -25,4 +25,9 @@ module StackedDecks
         Creeper.new(3, "extra death", "some rules text"),
         Creeper.new(2, "extra taxes", "some rules text"),
     ]
+
+    STARTS_WITH_NO_HAND_LIMIT =
+    [
+        Limit.new("max of 1", 3, "put some rule text here", 1)
+    ]
 end

--- a/constants/stacked_decks.rb
+++ b/constants/stacked_decks.rb
@@ -7,18 +7,18 @@ module StackedDecks
     keeper2 = Keeper.new(2, "two")
 
     QUICK_WIN =
-        [
-            keeper1,
-            Keeper.new(0, "doesn't matter"),
-            Keeper.new(0, "doesn't matter"),
-            Keeper.new(0, "doesn't matter"),
-            Keeper.new(0, "doesn't matter"),
-            Keeper.new(0, "doesn't matter"),
-            Keeper.new(0, "doesn't matter"),
-            keeper2,
-            Goal.new("one and two", [keeper1, keeper2], "Have keeper1 & keeper2"),
-            Rule.new("Play forever", 2, "XXXXXa"),
-        ]
+    [
+        keeper1,
+        Keeper.new(0, "doesn't matter"), # these are for the rest of the game setup
+        Keeper.new(0, "doesn't matter"), #   that way the next card player1 grabs is
+        Keeper.new(0, "doesn't matter"), #   the keeper1 card
+        Keeper.new(0, "doesn't matter"),
+        Keeper.new(0, "doesn't matter"),
+        Keeper.new(0, "doesn't matter"),
+        keeper2,
+        Goal.new("one and two", [keeper1, keeper2], "Have keeper1 & keeper2"),
+        Rule.new("Play forever", 2, "XXXXXa"),
+    ]
 
     DISCARD_TO_DEATH_ON_FIRST_TURN =
     [

--- a/constants/stacked_decks.rb
+++ b/constants/stacked_decks.rb
@@ -1,0 +1,22 @@
+module StackedDecks
+    def StackedDecks.stacked_deck_factory(logger, deck_list)
+        StackedDeck.new(logger, deck_list)
+    end
+
+    keeper1 = Keeper.new(1, "one")
+    keeper2 = Keeper.new(2, "two")
+
+    QUICK_WIN =
+        [
+            keeper1,
+            Keeper.new(0, "doesn't matter"),
+            Keeper.new(0, "doesn't matter"),
+            Keeper.new(0, "doesn't matter"),
+            Keeper.new(0, "doesn't matter"),
+            Keeper.new(0, "doesn't matter"),
+            Keeper.new(0, "doesn't matter"),
+            keeper2,
+            Goal.new("one and two", [keeper1, keeper2], "Have keeper1 & keeper2"),
+            Rule.new("Play forever", 2, "XXXXXa"),
+        ]
+end

--- a/deck.rb
+++ b/deck.rb
@@ -16,16 +16,12 @@ class Deck
   def drawCards(number=-1)
     cardsToDraw = (number != -1 ? number : 1)
     drawnCards = []
-    # puts "what is the value of #{@firstCard}"
     # put in for debugging
     # if @firstCard
     #   @firstCard = false
-    #   # newInjectedCard = Action.new(16,"extra exchange keepers", "put some rule text here")
-    #   # newInjectedCard = Limit.new("no keepers", 4, "put some rule text here", 0)
-    #   newInjectedCard = Creeper.new(1, "wanna be war", "Some rule text")
-    #   newInjectedCard2 = Creeper.new(3, "wanna be death", "Some rule text")
-    #   drawnCards = [newInjectedCard, newInjectedCard2]
-    #   drawnCards << Keeper.new(16, "pease")
+    #   newInjectedCard = Action.new(16,"extra exchange keepers", "put some rule text here")
+    #   drawnCards = [newInjectedCard]
+    #   # drawnCards << Keeper.new(16, "pease")
     #   cardsToDraw -= 1
     # end
     @interface.debug "draw #{cardsToDraw} card(s) from the game..."

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -7,7 +7,7 @@ require './gui_input_manager.rb'
 require './game_driver.rb'
 
 class GameGui < Gosu::Window
-    def initialize(logger, prompt_strings, user_prompt_templates)
+    def initialize(logger, prompt_strings, user_prompt_templates, deck)
         super 640, 960
         self.caption = "Fluxx"
 
@@ -35,6 +35,8 @@ class GameGui < Gosu::Window
             initialize_dialog_prompts(prompt_strings))
 
         @user_prompt_templates = user_prompt_templates
+        @deck = deck
+
         @new_game_driver = nil
 
         @current_cached_player = nil
@@ -75,7 +77,7 @@ class GameGui < Gosu::Window
                             # TODO:: should check to make sure @current_dialog exists
                             @current_dialog.add_prompt(key, Gosu::Image.from_text(prompt, 20))
                         end
-                        @game = Game.new(@logger, GuiInputManager.new(self), players)
+                        @game = Game.new(@logger, GuiInputManager.new(self), players, Random.new, @deck)
                         @game.setup
                         @new_game_driver = GameDriver.new(@game, @logger)
                         @current_cached_player = @new_game_driver.await.active_player.value

--- a/main.rb
+++ b/main.rb
@@ -30,7 +30,7 @@ logger.level = debug ? Logger::DEBUG : Logger::INFO
 the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
 
 if gui
-  guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS)
+  guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS, the_deck)
   guiGame.show
 else
   players = Player.generate_players(3)

--- a/main.rb
+++ b/main.rb
@@ -5,6 +5,7 @@ require "./game_cli.rb"
 require "./game_gui.rb"
 require "./game_driver.rb"
 require "./constants/prompts.rb"
+require "./constants/stacked_decks.rb"
 
 debug=false
 gui=false
@@ -26,20 +27,7 @@ logger = Logger.new($stdout)
 logger.level = debug ? Logger::DEBUG : Logger::INFO
 
 # the_deck = Deck.new(logger)
-keeper1 = Keeper.new(1, "one")
-keeper2 = Keeper.new(2, "two")
-the_deck = StackedDeck.new(logger, [
-  keeper1,
-  Keeper.new(0, "doesn't matter"),
-  Keeper.new(0, "doesn't matter"),
-  Keeper.new(0, "doesn't matter"),
-  Keeper.new(0, "doesn't matter"),
-  Keeper.new(0, "doesn't matter"),
-  Keeper.new(0, "doesn't matter"),
-  keeper2,
-  Goal.new("one and two", [keeper1, keeper2], "Have keeper1 & keeper2"),
-  Rule.new("Play forever", 2, "XXXXXa"),
-])
+the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
 
 if gui
   guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS)

--- a/main.rb
+++ b/main.rb
@@ -25,7 +25,21 @@ puts "starting game where debug: #{debug} and gui: #{gui}"
 logger = Logger.new($stdout)
 logger.level = debug ? Logger::DEBUG : Logger::INFO
 
-the_deck = Deck.new(logger)
+# the_deck = Deck.new(logger)
+keeper1 = Keeper.new(1, "one")
+keeper2 = Keeper.new(2, "two")
+the_deck = StackedDeck.new(logger, [
+  keeper1,
+  Keeper.new(0, "doesn't matter"),
+  Keeper.new(0, "doesn't matter"),
+  Keeper.new(0, "doesn't matter"),
+  Keeper.new(0, "doesn't matter"),
+  Keeper.new(0, "doesn't matter"),
+  Keeper.new(0, "doesn't matter"),
+  keeper2,
+  Goal.new("one and two", [keeper1, keeper2], "Have keeper1 & keeper2"),
+  Rule.new("Play forever", 2, "XXXXXa"),
+])
 
 if gui
   guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS)

--- a/main.rb
+++ b/main.rb
@@ -26,8 +26,8 @@ puts "starting game where debug: #{debug} and gui: #{gui}"
 logger = Logger.new($stdout)
 logger.level = debug ? Logger::DEBUG : Logger::INFO
 
-# the_deck = Deck.new(logger)
-the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
+the_deck = Deck.new(logger)
+# the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
 
 if gui
   guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS, the_deck)

--- a/main.rb
+++ b/main.rb
@@ -25,6 +25,8 @@ puts "starting game where debug: #{debug} and gui: #{gui}"
 logger = Logger.new($stdout)
 logger.level = debug ? Logger::DEBUG : Logger::INFO
 
+the_deck = Deck.new(logger)
+
 if gui
   guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS)
   guiGame.show
@@ -33,7 +35,7 @@ else
   player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
   prompt_strings = Constants::PROMPT_STRINGS.merge(player_prompts)
   cli_interface = CliInterface.new(prompt_strings)
-  theGame = Game.new(logger, cli_interface, players)
+  theGame = Game.new(logger, cli_interface, players, Random.new, the_deck)
   theGame.setup
   gameDriver = GameCli.new(theGame, logger, GameDriver.new(theGame, logger), cli_interface)
   gameDriver.run


### PR DESCRIPTION
Should allow for quicker building of manual test scenarios as well as less churn in `deck.rb` since I will no longer be injecting cards by changing how dealing works. I will just use a preconfigured stacked deck or create a new one.

_Edit: since creating this I have started trying to stack PRs better so this is now dependent on #47. To look at a more likely diff take a look [here](https://github.com/jjm3x3/flux/compare/feature/clean-up-mixed-prompt-style...feature/inject-decks)_