### PR TITLE
Print out opponents permanents and hand size

### DIFF
--- a/game_interface.rb
+++ b/game_interface.rb
@@ -72,6 +72,10 @@ class CliInterface < BaseTextInterface
     @output_stream.puts "here is the current goal: #{game.goal}"
     @output_stream.puts "here are the current rules:#{game.ruleBase}"
     activePlayer = game_driver.await.active_player.value
+    game.opponents(activePlayer).each do |player|
+      print_permanents(player, "Here are the permanants #{player} has:")
+      @output_stream.puts "With #{player.hand.length} cards in hand"
+    end
     @output_stream.puts "\n#{activePlayer}'s turn"
   end
 


### PR DESCRIPTION
Here is a super simple fix to give a the cli/tui player more context of what's going on with their opponents. At least at the beginning of the turn.

_Edit: since I am now stacking diffs this is based on #48 and a better diff can be seen [here](https://github.com/jjm3x3/flux/compare/feature/inject-decks...feature/add-opponent-info-to-cli) in the meantime_