### PR TITLE
Feature/improve card dialog2

### DIFF
--- a/constants/stacked_decks.rb
+++ b/constants/stacked_decks.rb
@@ -30,4 +30,11 @@ module StackedDecks
     [
         Limit.new("max of 1", 3, "put some rule text here", 1)
     ]
+
+    EXTRA_LONG_DIALOG_COMBO =
+    [
+        Limit.new("No hands", 3, "some rules text", 0),
+        Rule.new("Draw 9", 1, "XXXXX9"),
+        Rule.new("Play tree", 2, "XXXXX3"),
+    ]
 end

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -218,9 +218,9 @@ class GameGui < Gosu::Window
     # "TrueGuiInterface" stuff... well it used to be
     def display_list_dialog(list, prompt_key)
         @logger.debug "GameGui::display_list_dialog called with prompt_key: '#{prompt_key}'"
+        @current_dialog.set_cards(list)
         @current_dialog.set_prompt prompt_key
         @current_dialog.reset_result
-        @current_dialog.set_cards(list)
         @current_dialog.show
     end
 

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -28,6 +28,11 @@ class GameGui < Gosu::Window
 
         @are_you_sure_dialog = Dialog.new(self, @button_options)
 
+        dialog_background = Gosu::record(10,10) do
+            my_green = Gosu::Color.new(255,0, 128, 0)
+            Gosu::draw_rect(0, 0, 10, 10, my_green, ZOrder::DIALOG)
+        end
+
         @current_dialog = CardDialog.new(
             self,
             Gosu::Image.new("assets/onlineGreenSquare2.png", tileable: true),

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -35,7 +35,7 @@ class GameGui < Gosu::Window
 
         @current_dialog = CardDialog.new(
             self,
-            Gosu::Image.new("assets/onlineGreenSquare2.png", tileable: true),
+            dialog_background,
             Gosu::Font.new(20),
             logger,
             initialize_dialog_prompts(prompt_strings), @button_options)

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -1,3 +1,4 @@
+require "./gui_elements/button.rb"
 require "./gui_elements/zorder.rb"
 
 class Dialog

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -91,6 +91,7 @@ class CardDialog
     end
 
     def draw
+        if !@current_prompt_image; raise "Cannot draw a dialog without setting the prompt"; end
         if @visible
             x_scale = @width / @background.width
             @background.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, x_scale, 30)

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -54,7 +54,7 @@ class CardDialog
         @window = window
         @logger = logger
         @visible = false
-        @baground_image = background
+        @background = background
         @font = font
         @button_options = button_options
         @card_buttons = []
@@ -91,7 +91,8 @@ class CardDialog
 
     def draw
         if @visible
-            @baground_image.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, 0.25, 0.25)
+            @background.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, 30, 30)
+
             @current_prompt_image.draw(@dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
             @card_buttons.each do |card_button|
                 card_button.draw

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -67,6 +67,7 @@ class CardDialog
         @item_spacing = 10
         @dialog_prompts = dialog_prompts
         @current_prompt_image = dialog_prompts[:default]
+        @width = 300
     end
 
     def add_prompt(symbol, prompt_image)
@@ -91,7 +92,8 @@ class CardDialog
 
     def draw
         if @visible
-            @background.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, 30, 30)
+            x_scale = @width / @background.width
+            @background.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, x_scale, 30)
 
             @current_prompt_image.draw(@dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
             @card_buttons.each do |card_button|

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -89,7 +89,8 @@ class CardDialog
                                 @button_options)
             cardsDisplayed += 1
         end
-
+        # note cardsDisaplyed is really cardsDisplayed + 1 for the prompt
+        @height = (@font.height + @item_spacing) * cardsDisplayed + @boarder_width * 2
     end
 
     def draw

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -133,6 +133,8 @@ class CardDialog
         if !prompt_key; raise "prompt_key is nil"; end
         if !@dialog_prompts.has_key? prompt_key; raise "prompt_key missing from prompts collection"; end
         @current_prompt_image = @dialog_prompts[prompt_key]
+        # assuming the prompt is the longest thing set dialog width based on it
+        @width = @current_prompt_image.width + @boarder_width * 2
     end
 
     def handle_result

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -67,6 +67,8 @@ class CardDialog
         @item_spacing = 10
         @dialog_prompts = dialog_prompts
         @current_prompt_image = dialog_prompts[:default]
+        # height is assigned fairly arbitrarily here (assumes 3 options and prompt = 4)
+        @height = (@font.height + @item_spacing) * 4 + @boarder_width * 2
         @width = 300
     end
 
@@ -94,7 +96,8 @@ class CardDialog
         if !@current_prompt_image; raise "Cannot draw a dialog without setting the prompt"; end
         if @visible
             x_scale = @width / @background.width
-            @background.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, x_scale, 30)
+            y_scale = @height / @background.height
+            @background.draw(@dialog_x_position, @dialog_y_position, ZOrder::DIALOG, x_scale, y_scale)
 
             @current_prompt_image.draw(@dialog_content_x_position, @dialog_content_y_position, ZOrder::DIALOG_ITEMS)
             @card_buttons.each do |card_button|

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -122,15 +122,13 @@ describe "CardDialog" do
                 font_double,
                 test_logger,
                 {expected_prompt_key => prompt_image_double})
-            sut.set_prompt(expected_prompt_key)
             sut.show
 
 
-            # execute
-            sut.draw
-
-            # test
-            expect(background_double).to have_received(:draw).with(anything, anything, anything, expected_width, anything)
+            # Execute and Assert this should not fail
+            expect do
+                sut.draw
+            end.to raise_error("Cannot draw a dialog without setting the prompt")
         end
 
         it "should call draw with a width based on the prompt" do

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -14,7 +14,7 @@ describe "CardDialog" do
             font_double = instance_double("font")
             input_stream = StringIO.new("")
             test_logger = Logger.new(test_outfile)
-            prompt_image_double = double("prompt image", draw: nil)
+            prompt_image_double = double("prompt image", width: 1, draw: nil)
             expected_prompt_key = :some_expected_prompt
             sut = CardDialog.new(
                 gui_double,
@@ -88,6 +88,7 @@ describe "CardDialog" do
             font_double = instance_double("font", draw_text: nil)
             input_stream = StringIO.new("")
             test_logger = Logger.new(test_outfile)
+            prompt_image_double = double("prompt image", width: 1)
             sut = CardDialog.new(
                 gui_double,
                 background_double,
@@ -98,7 +99,7 @@ describe "CardDialog" do
             expected_prompt_key = :some_prompt_key
 
             # execute the test
-            sut.add_prompt(expected_prompt_key, double("SomeGosuImage"))
+            sut.add_prompt(expected_prompt_key, prompt_image_double)
 
             # Assert this should not fail
             sut.set_prompt(expected_prompt_key)
@@ -113,7 +114,33 @@ describe "CardDialog" do
             font_double = instance_double("font")
             test_logger = Logger.new(test_outfile)
             expected_width = 300 / background_double.width
-            prompt_image_double = double("prompt image", draw: nil)
+            prompt_image_double = double("prompt image", width: 1, draw: nil)
+            expected_prompt_key = :some_expected_prompt
+            sut = CardDialog.new(
+                gui_double,
+                background_double,
+                font_double,
+                test_logger,
+                {expected_prompt_key => prompt_image_double})
+            sut.set_prompt(expected_prompt_key)
+            sut.show
+
+
+            # execute
+            sut.draw
+
+            # test
+            expect(background_double).to have_received(:draw).with(anything, anything, anything, expected_width, anything)
+        end
+
+        it "should call draw with a width based on the prompt" do
+            # setup
+            gui_double = double("gui")
+            background_double = double("background", width: 1, draw: nil)
+            font_double = instance_double("font")
+            test_logger = Logger.new(test_outfile)
+            prompt_image_double = double("prompt image", width: 400, draw: nil)
+            expected_width = (prompt_image_double.width + 20 * 2) / background_double.width
             expected_prompt_key = :some_expected_prompt
             sut = CardDialog.new(
                 gui_double,

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -184,5 +184,36 @@ describe "CardDialog" do
             # test
             expect(background_double).to have_received(:draw).with(anything, anything, anything, anything, expected_height)
         end
+
+        it "should call draw with a height that is based on how many cards are set" do
+            pending("This test requires that buttons can be created which intern requries that buttons don't depend on Gosu")
+            # setup
+            gui_double = double("gui")
+            background_double = double("background", width: 1, height: 1, draw: nil)
+            font_double = instance_double("font", height: 1)
+            test_logger = Logger.new(test_outfile)
+            prompt_image_double = double("prompt image", width: 400, draw: nil)
+            mock_card_list = [1,2,3]
+            # This test is mostly asserting that the following calculation with
+            # all assumptions and constants is executed
+            expected_height = (font_double.height + 10) * (mock_card_list.length + 1) + 20 * 2
+            expected_prompt_key = :some_expected_prompt
+            sut = CardDialog.new(
+                gui_double,
+                background_double,
+                font_double,
+                test_logger,
+                {expected_prompt_key => prompt_image_double})
+            sut.set_prompt(expected_prompt_key)
+            sut.set_cards(mock_card_list)
+            sut.show
+
+
+            # execute
+            sut.draw
+
+            # test
+            expect(background_double).to have_received(:draw).with(anything, anything, anything, anything, expected_height)
+        end
     end
 end

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -10,8 +10,8 @@ describe "CardDialog" do
         it "should not call draw_text on font when prompt symbol is passed" do
             # setup
             gui_double = double("gui")
-            background_double = double("background", width: 1, draw: nil)
-            font_double = instance_double("font")
+            background_double = double("background", width: 1, height: 1, draw: nil)
+            font_double = instance_double("font", height: 1)
             input_stream = StringIO.new("")
             test_logger = Logger.new(test_outfile)
             prompt_image_double = double("prompt image", width: 1, draw: nil)
@@ -39,7 +39,7 @@ describe "CardDialog" do
             # setup
             gui_double = double("gui")
             background_double = double("background", draw: nil)
-            font_double = instance_double("font", draw_text: nil)
+            font_double = instance_double("font", height: 1)
             input_stream = StringIO.new("")
             test_logger = Logger.new(test_outfile)
             sut = CardDialog.new(
@@ -60,7 +60,7 @@ describe "CardDialog" do
             # setup
             gui_double = double("gui")
             background_double = double("background", draw: nil)
-            font_double = instance_double("font", draw_text: nil)
+            font_double = instance_double("font", height:1, draw_text: nil)
             input_stream = StringIO.new("")
             test_logger = Logger.new(test_outfile)
             sut = CardDialog.new(
@@ -85,7 +85,7 @@ describe "CardDialog" do
             # setup
             gui_double = double("gui")
             background_double = double("background", draw: nil)
-            font_double = instance_double("font", draw_text: nil)
+            font_double = instance_double("font", height: 1, draw_text: nil)
             input_stream = StringIO.new("")
             test_logger = Logger.new(test_outfile)
             prompt_image_double = double("prompt image", width: 1)
@@ -111,7 +111,7 @@ describe "CardDialog" do
             # setup
             gui_double = double("gui")
             background_double = double("background", width: 1, draw: nil)
-            font_double = instance_double("font")
+            font_double = instance_double("font", height:1)
             test_logger = Logger.new(test_outfile)
             expected_width = 300 / background_double.width
             prompt_image_double = double("prompt image", width: 1, draw: nil)
@@ -134,8 +134,8 @@ describe "CardDialog" do
         it "should call draw with a width based on the prompt" do
             # setup
             gui_double = double("gui")
-            background_double = double("background", width: 1, draw: nil)
-            font_double = instance_double("font")
+            background_double = double("background", width: 1, height: 1, draw: nil)
+            font_double = instance_double("font", height: 1)
             test_logger = Logger.new(test_outfile)
             prompt_image_double = double("prompt image", width: 400, draw: nil)
             expected_width = (prompt_image_double.width + 20 * 2) / background_double.width

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -10,7 +10,7 @@ describe "CardDialog" do
         it "should not call draw_text on font when prompt symbol is passed" do
             # setup
             gui_double = double("gui")
-            background_double = double("background", draw: nil)
+            background_double = double("background", width: 1, draw: nil)
             font_double = instance_double("font")
             input_stream = StringIO.new("")
             test_logger = Logger.new(test_outfile)

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -21,7 +21,7 @@ describe "CardDialog" do
                 background_double,
                 font_double,
                 test_logger,
-                {expected_prompt_key => prompt_image_double},
+                dialog_prompts={expected_prompt_key => prompt_image_double},
                 button_options={})
 
             # setup lite
@@ -121,7 +121,8 @@ describe "CardDialog" do
                 background_double,
                 font_double,
                 test_logger,
-                {expected_prompt_key => prompt_image_double})
+                dialog_prompts={expected_prompt_key => prompt_image_double},
+                button_options={})
             sut.show
 
 
@@ -145,7 +146,8 @@ describe "CardDialog" do
                 background_double,
                 font_double,
                 test_logger,
-                {expected_prompt_key => prompt_image_double})
+                dialog_prompts={expected_prompt_key => prompt_image_double},
+                button_options={})
             sut.set_prompt(expected_prompt_key)
             sut.show
 
@@ -173,7 +175,8 @@ describe "CardDialog" do
                 background_double,
                 font_double,
                 test_logger,
-                {expected_prompt_key => prompt_image_double})
+                dialog_prompts={expected_prompt_key => prompt_image_double},
+                button_options={})
             sut.set_prompt(expected_prompt_key)
             sut.show
 
@@ -186,11 +189,10 @@ describe "CardDialog" do
         end
 
         it "should call draw with a height that is based on how many cards are set" do
-            pending("This test requires that buttons can be created which intern requries that buttons don't depend on Gosu")
             # setup
             gui_double = double("gui")
             background_double = double("background", width: 1, height: 1, draw: nil)
-            font_double = instance_double("font", height: 1)
+            font_double = instance_double("font", height: 1, draw_text: nil)
             test_logger = Logger.new(test_outfile)
             prompt_image_double = double("prompt image", width: 400, draw: nil)
             mock_card_list = [1,2,3]
@@ -203,7 +205,8 @@ describe "CardDialog" do
                 background_double,
                 font_double,
                 test_logger,
-                {expected_prompt_key => prompt_image_double})
+                dialog_prompts={expected_prompt_key => prompt_image_double},
+                button_options={is_pressed: -> () {} })
             sut.set_prompt(expected_prompt_key)
             sut.set_cards(mock_card_list)
             sut.show

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -156,5 +156,33 @@ describe "CardDialog" do
             # test
             expect(background_double).to have_received(:draw).with(anything, anything, anything, expected_width, anything)
         end
+
+        it "should call draw with the default height when no cards set" do
+            # setup
+            gui_double = double("gui")
+            background_double = double("background", width: 1, height: 1, draw: nil)
+            font_double = instance_double("font", height: 1)
+            test_logger = Logger.new(test_outfile)
+            prompt_image_double = double("prompt image", width: 400, draw: nil)
+            # This test is mostly asserting that the following calculation with
+            # all assumptions and constants is executed
+            expected_height = (font_double.height + 10) * 4 + 20 * 2
+            expected_prompt_key = :some_expected_prompt
+            sut = CardDialog.new(
+                gui_double,
+                background_double,
+                font_double,
+                test_logger,
+                {expected_prompt_key => prompt_image_double})
+            sut.set_prompt(expected_prompt_key)
+            sut.show
+
+
+            # execute
+            sut.draw
+
+            # test
+            expect(background_double).to have_received(:draw).with(anything, anything, anything, anything, expected_height)
+        end
     end
 end

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -104,4 +104,32 @@ describe "CardDialog" do
             sut.set_prompt(expected_prompt_key)
         end
     end
+
+    describe "draw" do
+        it "should call draw with the right intial width" do
+            # setup
+            gui_double = double("gui")
+            background_double = double("background", width: 1, draw: nil)
+            font_double = instance_double("font")
+            test_logger = Logger.new(test_outfile)
+            expected_width = 300 / background_double.width
+            prompt_image_double = double("prompt image", draw: nil)
+            expected_prompt_key = :some_expected_prompt
+            sut = CardDialog.new(
+                gui_double,
+                background_double,
+                font_double,
+                test_logger,
+                {expected_prompt_key => prompt_image_double})
+            sut.set_prompt(expected_prompt_key)
+            sut.show
+
+
+            # execute
+            sut.draw
+
+            # test
+            expect(background_double).to have_received(:draw).with(anything, anything, anything, expected_width, anything)
+        end
+    end
 end


### PR DESCRIPTION
This does a few things but the bulk of this change will remove the need for a static asset to render the dialog and also allow for the dialog to be dynamically sized based on how long the prompt is and how long the card list is.

_Note: there is one new "pending" test since it relies on the `Button` class which has not been decoupled from Gosu so it breaks_