### PR TITLE
Feature/split dialog use cases

### DIFF
--- a/constants/stacked_decks.rb
+++ b/constants/stacked_decks.rb
@@ -39,4 +39,10 @@ module StackedDecks
         Rule.new("Draw 9", 1, "XXXXX9"),
         Rule.new("Play tree", 2, "XXXXX3"),
     ]
+
+    NON_CARD_DIALOGS =
+    [
+        Rule.new("Play forever", 2, "XXXXXa"),
+        Action.new(9, "What a special day", "Rules for todays special")
+    ]
 end

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -11,6 +11,8 @@ class GameGui < Gosu::Window
         super 640, 960
         self.caption = "Fluxx"
 
+        @gui_input_manager =  GuiInputManager.new(self)
+
         @bakground_image = Gosu::Image.new("assets/onlinePurpleSquare.jpg", tileable: true)
         @font = Gosu::Font.new(20)
 
@@ -85,7 +87,7 @@ class GameGui < Gosu::Window
            # TODO:: should check to make sure @list_dialog exists
            @list_dialog.add_prompt(key, Gosu::Image.from_text(prompt, 20))
        end
-       @game = Game.new(@logger, GuiInputManager.new(self), players, Random.new, @deck)
+       @game = Game.new(@logger, @gui_input_manager, players, Random.new, @deck)
        @game.setup
        @new_game_driver = GameDriver.new(@game, @logger)
        @current_cached_player = @new_game_driver.await.active_player.value

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -105,10 +105,11 @@ class GameGui < Gosu::Window
                 return
             end
             if @simple_dialog && @simple_dialog.is_visible?
-                @simple_dialog.handle_result do |result|
-                    @logger.debug "GameGui:button_up: are you sure dialog result is: #{result}"
+                if @simple_dialog.handle_result
+                    current_result = @simple_dialog.get_result
+                    @logger.debug "GameGui::button_up: the dialog starting a new game has result '#{current_result}'"
                     @simple_dialog.hide
-                    if result == "Yes"
+                    if current_result == "Yes"
                         @new_game_button.set_visibility false
                         start_a_new_game
                     elsif result == "Back to Main Menu"

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -245,11 +245,24 @@ class GameGui < Gosu::Window
         @list_dialog.draw
     end
 
+    # "TrueGuiInterface" stuff... well it used to be
     def get_dialog_result
         @list_dialog.get_result
     end
 
-    # "TrueGuiInterface" stuff... well it used to be
+    def get_simple_dialog_result
+        @simple_dialog.get_result
+    end
+
+    def display_simple_dialog(list, prompt_key)
+        @logger.debug "GameGui::display_simple_dialog called with prompt_key: '#{prompt_key}'"
+        @simple_dialog.set_options(list)
+        @simple_dialog.set_prompt prompt_key
+        @simple_dialog.reset_result
+        @logger.debug "After reseting the result of the simple dialog is '#{}'"
+        @simple_dialog.show
+    end
+
     def display_list_dialog(list, prompt_key)
         @logger.debug "GameGui::display_list_dialog called with prompt_key: '#{prompt_key}'"
         @list_dialog.set_options(list)

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -211,6 +211,10 @@ class GameGui < Gosu::Window
         @game_stats.draw(@game)
 
         activePlayer = @current_cached_player
+        # adding a nil check here since during game setup there is a race condtion
+        if !activePlayer
+            return
+        end
         @font.draw_text("It is player #{activePlayer}'s turn'", 10, 10 + @game_stats.height + 10, 1, 1.0, 1.0, Gosu::Color::WHITE)
 
         @font.draw_text("Here are the permanents they have:", 10, 10 + @game_stats.height + 10 + @font.height + 10, 1, 1.0, 1.0, Gosu::Color::WHITE)

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -34,7 +34,7 @@ class GameGui < Gosu::Window
 
         dialog_prompts = initialize_dialog_prompts(prompt_strings)
 
-        @simple_dialog = SimpleDialog.new(
+        @simple_dialog = AsyncDialog.new(
             self,
             dialog_background,
             Gosu::Font.new(20),

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -108,6 +108,13 @@ class GameGui < Gosu::Window
             end
             if @simple_dialog && @simple_dialog.is_visible?
                 if @simple_dialog.handle_result
+                    @simple_dialog.hide
+                end
+                return
+            end
+            if @new_game_button.is_clicked?
+                start_game_future = @gui_input_manager.async.ask_yes_no(:play_a_game_prompt)
+                start_game_future.add_observer do |time, value|
                     current_result = @simple_dialog.get_result
                     @logger.debug "GameGui::button_up: the dialog starting a new game has result '#{current_result}'"
                     @simple_dialog.hide
@@ -118,11 +125,8 @@ class GameGui < Gosu::Window
                         @new_game_driver = nil
                     end
                     # TODO:: do things for other cases
+                    @logger.debug "GameGui:button_up: start_game_future came back with value: #{value}"
                 end
-                return
-            end
-            if @new_game_button.is_clicked?
-                @simple_dialog.show
                 return
             end
             clickedCard = 0

--- a/gui_input_manager.rb
+++ b/gui_input_manager.rb
@@ -23,23 +23,25 @@ class GuiInputManager
 
     def ask_yes_no(prompt)
         yes_string = "Yes"
-        @gui.display_list_dialog([yes_string, "No"], prompt)
+        @gui.display_simple_dialog([yes_string, "No"], prompt)
         dialog_result = nil
+        puts "Before starting the loop the result is: '#{@gui.get_simple_dialog_result}'"
         while !dialog_result
             sleep @sleep_amount
-            dialog_result = @gui.get_dialog_result
+            dialog_result = @gui.get_simple_dialog_result
+            puts "What is the result '#{dialog_result}'"
         end
         return dialog_result == yes_string
     end
 
     def ask_rotation(prompt)
         clockwise_string = "Clockwise"
-        @gui.display_list_dialog([clockwise_string, "Counter Clockwise"], prompt)
+        @gui.display_simple_dialog([clockwise_string, "Counter Clockwise"], prompt)
 
         dialog_result = nil
         while !dialog_result
             sleep @sleep_amount
-            dialog_result = @gui.get_dialog_result
+            dialog_result = @gui.get_simple_dialog_result
         end
 
         return dialog_result == clockwise_string ? Direction::Clockwise : Direction::CounterClockwise

--- a/gui_input_manager.rb
+++ b/gui_input_manager.rb
@@ -25,11 +25,9 @@ class GuiInputManager
         yes_string = "Yes"
         @gui.display_simple_dialog([yes_string, "No"], prompt)
         dialog_result = nil
-        puts "Before starting the loop the result is: '#{@gui.get_simple_dialog_result}'"
         while !dialog_result
             sleep @sleep_amount
             dialog_result = @gui.get_simple_dialog_result
-            puts "What is the result '#{dialog_result}'"
         end
         return dialog_result == yes_string
     end


### PR DESCRIPTION
Even though we just merged a lot of the base code for the dialog classes that doesn't mean that there isn't a distinction. In fact the game_gui maintained two different instances which have almost no difference code wise. The main difference between them however is that in the future the current `CardDialog` will likely display card assets for the player to interact with. This is not true for all dialogs so this is the first step to make sure that any known non card cases can work with the simple dialog and then all the card specific cases can be used with the `SimpleDialog`. Naturally this change depends on a few before it (namely #54 & #53) until that time a practical diff can be seen [here](https://github.com/jjm3x3/flux/compare/feature/make-are-you-sure-async...feature/split-dialog-use-cases)