### PR TITLE
Feateur/log debug level by default

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -15,7 +15,8 @@ OptionParser.new do |opt|
   opt.on("--gui") { |o| options[:gui] = o }
 end.parse!
 
-puts "starting game where debug: #{options[:debug] == true} and gui: #{options[:gui] == true}"
+log_level = (options[:log_level] ? options[:log_level] : Logger::DEBUG)
+puts "starting game where debug: #{options[:debug] == true} and log_level: #{log_level} and gui: #{options[:gui] == true}"
 
 logger = Logger.new($stdout)
 logger.level = options[:debug] ? Logger::DEBUG : Logger::INFO

--- a/main.rb
+++ b/main.rb
@@ -10,13 +10,12 @@ require "./constants/stacked_decks.rb"
 
 options = {}
 OptionParser.new do |opt|
-  opt.on("--debug") { |o| options[:debug] = o }
   opt.on("--log-level LEVEL") { |o| options[:log_level] = o }
   opt.on("--gui") { |o| options[:gui] = o }
 end.parse!
 
 log_level = (options[:log_level] ? options[:log_level] : Logger::DEBUG)
-puts "starting game where debug: #{options[:debug] == true} and log_level: #{log_level} and gui: #{options[:gui] == true}"
+puts "starting game where log_level: #{log_level} and gui: #{options[:gui] == true}"
 
 logger = Logger.new($stdout)
 logger.level = log_level

--- a/main.rb
+++ b/main.rb
@@ -19,7 +19,7 @@ log_level = (options[:log_level] ? options[:log_level] : Logger::DEBUG)
 puts "starting game where debug: #{options[:debug] == true} and log_level: #{log_level} and gui: #{options[:gui] == true}"
 
 logger = Logger.new($stdout)
-logger.level = options[:debug] ? Logger::DEBUG : Logger::INFO
+logger.level = log_level
 
 the_deck = Deck.new(logger)
 # the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)

--- a/main.rb
+++ b/main.rb
@@ -11,6 +11,7 @@ require "./constants/stacked_decks.rb"
 options = {}
 OptionParser.new do |opt|
   opt.on("--debug") { |o| options[:debug] = o }
+  opt.on("--log-level LEVEL") { |o| options[:log_level] = o }
   opt.on("--gui") { |o| options[:gui] = o }
 end.parse!
 


### PR DESCRIPTION
Exactly as its name implies. As I get ready to release the first beta version of this I want to make sure that logging is turned all the way up to debug by default. This game doesn't generate that many logs at this time and the log files themselves are ephemeral so might as well have it up as high as it goes until the kinks are worked out.

_Note: this diff relies on several before #54, #53 and #55 so this should be in draft until those close_