### PR TITLE
Feature/run gui by default

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -11,12 +11,11 @@ require "./constants/stacked_decks.rb"
 options = {}
 OptionParser.new do |opt|
   opt.on("--log-level LEVEL") { |o| options[:log_level] = o }
-  opt.on("--gui") { |o| options[:gui] = o }
   opt.on("--cli") { |o| options[:cli] = o }
 end.parse!
 
 log_level = (options[:log_level] ? options[:log_level] : Logger::DEBUG)
-puts "starting game where log_level: #{log_level} and gui: #{options[:gui] == true} and cli #{options[:cli] == true}"
+puts "starting game where log_level: #{log_level} and cli #{options[:cli] == true}"
 
 logger = Logger.new($stdout)
 logger.level = log_level

--- a/main.rb
+++ b/main.rb
@@ -12,10 +12,11 @@ options = {}
 OptionParser.new do |opt|
   opt.on("--log-level LEVEL") { |o| options[:log_level] = o }
   opt.on("--gui") { |o| options[:gui] = o }
+  opt.on("--cli") { |o| options[:cli] = o }
 end.parse!
 
 log_level = (options[:log_level] ? options[:log_level] : Logger::DEBUG)
-puts "starting game where log_level: #{log_level} and gui: #{options[:gui] == true}"
+puts "starting game where log_level: #{log_level} and gui: #{options[:gui] == true} and cli #{options[:cli] == true}"
 
 logger = Logger.new($stdout)
 logger.level = log_level

--- a/main.rb
+++ b/main.rb
@@ -24,7 +24,7 @@ logger.level = log_level
 the_deck = Deck.new(logger)
 # the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
 
-if options[:gui]
+if !options[:cli]
   guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS, the_deck)
   guiGame.show
 else


### PR DESCRIPTION
Similar to #57 this is preparing for the first beta release of the game. In this case this just makes it easier to bundle it since I don't need to modify game source to get it working. In order to play the cli interface you will now need to provide the `--cli` flag when running it.

_Note: this diff relies on several before #54, #53, #55 and #57 so this should be in draft until those close_