### PR TITLE
Feature/add log to shell opt

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -12,7 +12,7 @@ options = {}
 OptionParser.new do |opt|
   opt.on("--log-level LEVEL") { |o| options[:log_level] = o }
   opt.on("--cli") { |o| options[:cli] = o }
-  opt.on("--output-to-shell") { |o| options[:output_to_shell] = o }
+  opt.on("--log-to-shell") { |o| options[:log_to_shell] = o }
 end.parse!
 
 log_level = (options[:log_level] ? options[:log_level] : Logger::DEBUG)

--- a/main.rb
+++ b/main.rb
@@ -18,7 +18,8 @@ end.parse!
 log_level = (options[:log_level] ? options[:log_level] : Logger::DEBUG)
 puts "starting game where log_level: #{log_level} and cli #{options[:cli] == true}"
 
-logger = Logger.new($stdout)
+output_stream = options[:log_to_shell] ? $stdout : "fluxx.log"
+logger = Logger.new(output_stream)
 logger.level = log_level
 
 the_deck = Deck.new(logger)

--- a/main.rb
+++ b/main.rb
@@ -12,6 +12,7 @@ options = {}
 OptionParser.new do |opt|
   opt.on("--log-level LEVEL") { |o| options[:log_level] = o }
   opt.on("--cli") { |o| options[:cli] = o }
+  opt.on("--output-to-shell") { |o| options[:output_to_shell] = o }
 end.parse!
 
 log_level = (options[:log_level] ? options[:log_level] : Logger::DEBUG)


### PR DESCRIPTION
This adds another option for when developing the game  it may be useful to log to the shell instead of a file. But once the game is bundled the default should write to a file.