### PR TITLE
Feature/improve boot strapping code

### DIFF
--- a/constants/stacked_decks.rb
+++ b/constants/stacked_decks.rb
@@ -1,3 +1,5 @@
+require "./cards/cards.rb"
+
 module StackedDecks
     def StackedDecks.stacked_deck_factory(logger, deck_list)
         StackedDeck.new(logger, deck_list)

--- a/main.rb
+++ b/main.rb
@@ -3,14 +3,40 @@ require "Logger"
 boot_strapping_logger = Logger.new("boot_strap.log")
 boot_strapping_logger.debug "Starting up game!"
 
-require "optparse"
-require "./game.rb"
-require "./game_interface.rb"
-require "./game_cli.rb"
-require "./game_gui.rb"
-require "./game_driver.rb"
-require "./constants/prompts.rb"
-require "./constants/stacked_decks.rb"
+loop do
+  begin
+    boot_strapping_logger.info "requiring deps"
+    require "optparse"
+    boot_strapping_logger.info "optparse required"
+    require "./game.rb"
+    boot_strapping_logger.info "game.rb required"
+    # TODO:: known issue with requireing game_interface which requires concurrent
+    #        seems like concurrent-ruby does some logger intialization which leads
+    #        to a warning like
+    #        `already initialized constant Logger::ProgName`
+    #        there doesn't seem to be any practical issue with this at this time.
+    require "./game_interface.rb"
+    boot_strapping_logger.info "game_interface.rb required"
+    require "./game_cli.rb"
+    boot_strapping_logger.info "game_cli.rb required"
+    require "./game_gui.rb"
+    boot_strapping_logger.info "game_gui.rb required"
+    require "./game_driver.rb"
+    boot_strapping_logger.info "game_driver.rb required"
+    require "./constants/prompts.rb"
+    boot_strapping_logger.info "constants/prompts.rb required"
+    require "./constants/stacked_decks.rb"
+    boot_strapping_logger.info "constants/stacked_decks.rb required"
+    break
+  rescue LoadError => ex
+    boot_strapping_logger.debug "loading some lib failed because: #{ex}"
+    boot_strapping_logger.debug "Stacktrace: #{ex.backtrace}"
+    boot_strapping_logger.debug "Stacktrace: #{ex.backtrace.inspect}"
+  end
+  sleep_duration = 10
+  boot_strapping_logger.debug "Going to sleep and try in #{sleep_duration} sec(s)..."
+  sleep sleep_duration
+end
 
 options = {}
 OptionParser.new do |opt|

--- a/main.rb
+++ b/main.rb
@@ -1,4 +1,8 @@
 #!/usr/local/bin/ruby
+require "Logger"
+boot_strapping_logger = Logger.new("boot_strap.log")
+boot_strapping_logger.debug "Starting up game!"
+
 require "optparse"
 require "./game.rb"
 require "./game_interface.rb"

--- a/main.rb
+++ b/main.rb
@@ -21,10 +21,14 @@ end.parse!
 
 log_level = (options[:log_level] ? options[:log_level] : Logger::DEBUG)
 puts "starting game where log_level: #{log_level} and cli #{options[:cli] == true}"
+boot_strapping_logger.info "starting game where log_level: #{log_level} and cli #{options[:cli] == true}"
 
 output_stream = options[:log_to_shell] ? $stdout : "fluxx.log"
 logger = Logger.new(output_stream)
 logger.level = log_level
+
+logger.debug "Starting up game!"
+boot_strapping_logger.close  # the app/game logger can take it from here
 
 the_deck = Deck.new(logger)
 # the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)

--- a/main.rb
+++ b/main.rb
@@ -59,10 +59,7 @@ boot_strapping_logger.close  # the app/game logger can take it from here
 the_deck = Deck.new(logger)
 # the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
 
-if !options[:cli]
-  guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS, the_deck)
-  guiGame.show
-else
+if options[:cli]
   players = Player.generate_players(3)
   player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
   prompt_strings = Constants::PROMPT_STRINGS.merge(player_prompts)
@@ -71,4 +68,7 @@ else
   theGame.setup
   gameDriver = GameCli.new(theGame, logger, GameDriver.new(theGame, logger), cli_interface)
   gameDriver.run
+else
+  guiGame = GameGui.new(logger, Constants::PROMPT_STRINGS, Constants::USER_SPECIFIC_PROMPTS, the_deck)
+  guiGame.show
 end


### PR DESCRIPTION
This branch does two things mainly
- Adds a second logger just for boot strapping and will make sure that all the subsequent requires are done in try catch in case there are any issues
- Flip the cli game option condition (this one just helps readability)


_Note: this depends on #59. so that must be merged first_