### PR TITLE
Feature/add image to buttons

### DIFF
--- a/gui_elements/button.rb
+++ b/gui_elements/button.rb
@@ -40,10 +40,19 @@ class Button
 
     private
     def intersects
+        x_max = 0
+        y_max = 0
+        if @image
+            x_max = @image.width
+            y_max = @image.height
+        else
+            x_max = @font.text_width(@text)
+            y_max = @font.height
+        end
         mouse_past_left = @window.mouse_x > @x
-        mouse_past_right = @window.mouse_x >= @x + @font.text_width(@text)
+        mouse_past_right = @window.mouse_x >= @x + x_max
         mouse_below_top = @window.mouse_y > @y
-        mouse_above_bottom = @window.mouse_y < @y + @font.height
+        mouse_above_bottom = @window.mouse_y < @y + y_max
         mouse_past_left && !mouse_past_right && mouse_below_top && mouse_above_bottom
     end
 end

--- a/gui_elements/button.rb
+++ b/gui_elements/button.rb
@@ -1,11 +1,12 @@
 class Button
-    def initialize(window, font, text, x, y, z, options={})
+    def initialize(window, font, text, x, y, z, options={}, image=nil)
         @window = window
         @text = text
         @x = x
         @y = y
         @z = z
         @font = font
+        @image = image
         @visible = true
         @is_pressed = options[:is_pressed]
         @pressed_color = options[:pressed_color]

--- a/gui_elements/button.rb
+++ b/gui_elements/button.rb
@@ -17,7 +17,11 @@ class Button
         left_click_down = @is_pressed.call
 
         textcolor = left_click_down && intersects ? @pressed_color : @unpressed_color
-        @font.draw_text(@text, @x , @y, @z , 1.0, 1.0, textcolor)
+        if @image
+            @image.draw(@x , @y, @z, 1, 1, textcolor)
+        else
+            @font.draw_text(@text, @x , @y, @z , 1.0, 1.0, textcolor)
+        end
     end
 
     def is_clicked?

--- a/tests/gui_elements/button_spec.rb
+++ b/tests/gui_elements/button_spec.rb
@@ -28,6 +28,20 @@ describe "Button" do
             # assert
             # nothing much to assert just making sure this works
         end
+
+        it "should prefer drawing an image if one is injected" do
+            # setup
+            window_double = double("window")
+            font_double = double("font", draw_text: nil)
+            image_double = double("image", draw: nil)
+            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} }, image_double)
+
+            # execute
+            sut.draw
+
+            # assert
+            expect(image_double).to have_received(:draw)
+        end
     end
 
     describe "set_position" do

--- a/tests/gui_elements/button_spec.rb
+++ b/tests/gui_elements/button_spec.rb
@@ -44,6 +44,22 @@ describe "Button" do
         end
     end
 
+    describe "is_clicked?" do
+        it "should interset with image when one is provided" do
+            # setup
+            window_double = double("window", mouse_x: 150 , mouse_y: 150)
+            font_double = double("font", text_width: 100, height: 100)
+            image_double = double("image", width: 200, height: 200)
+            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} }, image_double)
+
+            # execute
+            result = sut.is_clicked?
+
+            # assert
+            expect(result).to be true
+        end
+    end
+
     describe "set_position" do
         it "should draw based what what is porvided in set_position" do
             # setup


### PR DESCRIPTION
Just as the name suggests here we are adding an optional parameter (image) which will be preferred for all operations on button and will in the future be removed in favor of making it the only mode of operation. In order to make sure this work was completed I have created [this compensating branch](https://github.com/jjm3x3/flux/tree/feature/remove-font-and-text-for-image) which should be merged in as soon as we can safely do so. ~Since that branch is a bit away from being merged see an effective diff [here](https://github.com/jjm3x3/flux/compare/feature/update-dialog-options...feature/remove-font-and-text-for-image) if you are curious.~ PR is now open here #82 