### PR TITLE
Feature/create button image repo

### DIFF
--- a/deck.rb
+++ b/deck.rb
@@ -31,6 +31,12 @@ class Deck
     drawnCards
   end
 
+  def each
+    @cards.each do |card|
+      yield card
+    end
+  end
+
   def count
     @cards.length
   end

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -59,12 +59,23 @@ class GameGui < Gosu::Window
         @user_prompt_templates = user_prompt_templates
         @deck = deck
 
+        @button_images = create_card_images(@deck)
+
         @new_game_driver = nil
 
         @current_cached_player = nil
         @current_player_future = nil
 
         @play_card_future = nil
+    end
+
+    def create_card_images(deck)
+        result = {}
+        deck.each do |card|
+            result[card.name] = Gosu::Image.from_text(card.name.to_s, 20)
+        end
+
+        return result
     end
 
     def initialize_dialog_prompts(prompt_strings)

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -95,6 +95,9 @@ class GameGui < Gosu::Window
         @logger.debug "I am starting a game then"
         numberOfPlayers = 3
         players = Player.generate_players(numberOfPlayers)
+        players.each do |player|
+            @button_images[player.name] = Gosu::Image.from_text(player.name, 20)
+        end
         PlayerPromptGenerator.generate_prompts(players, @user_prompt_templates).each do |key, prompt|
             # TODO:: should check to make sure @list_dialog exists
             @list_dialog.add_prompt(key, Gosu::Image.from_text(prompt, 20))

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -59,7 +59,11 @@ class GameGui < Gosu::Window
         @user_prompt_templates = user_prompt_templates
         @deck = deck
 
-        @button_images = create_card_images(@deck)
+        @button_images = {
+            "Yes": Gosu::Image.from_text("Yes", 20),
+            "No": Gosu::Image.from_text("No", 20),
+        }
+        @button_images = @button_images.merge(create_card_images(@deck))
 
         @new_game_driver = nil
 

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -62,6 +62,9 @@ class GameGui < Gosu::Window
         @button_images = {
             "Yes": Gosu::Image.from_text("Yes", 20),
             "No": Gosu::Image.from_text("No", 20),
+            "Clockwise": Gosu::Image.from_text("Clockwise", 20),
+            "Counter Clockwise": Gosu::Image.from_text("Counter Clockwise", 20),
+            "Back to Main Menu": Gosu::Image.from_text("Back to Main Menu", 20),
         }
         @button_images = @button_images.merge(create_card_images(@deck))
 

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -6,6 +6,7 @@ class SimpleDialog
         list_options = []
         list.each do |item|
             list_option = {item: item}
+            if !images.has_key? item.to_s; raise "No image found for item #{item.to_s} in image hash"; end
             list_option[:image] = images[item.to_s]
             list_options << list_option
         end

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -2,6 +2,16 @@ require "./gui_elements/button.rb"
 require "./gui_elements/zorder.rb"
 
 class SimpleDialog
+    def self.generate_dialog_options(list, images)
+        list_options = []
+        list.each do |item|
+            list_option = {item: item}
+            list_option[:image] = images[item.name]
+            list_options << list_option
+        end
+        return list_options
+    end
+
     def initialize(window, background, font, logger, dialog_prompts, button_options)
         @window = window
         @background = background

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -6,7 +6,7 @@ class SimpleDialog
         list_options = []
         list.each do |item|
             list_option = {item: item}
-            list_option[:image] = images[item.name]
+            list_option[:image] = images[item.to_s]
             list_options << list_option
         end
         return list_options

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -20,6 +20,26 @@ describe "SimpleDialog" do
             # test
             #  none of the above calls should fail
         end
+
+        it "should raise an exception if there is no image with that name" do
+            # setup
+            test_player = Player.new("TestPlayer")
+            test_card = Card.new
+
+            # execute
+            expect do
+                SimpleDialog.generate_dialog_options(["yes", "no"], {})
+            end.to raise_error("No image found for item yes in image hash")
+            expect do
+                SimpleDialog.generate_dialog_options([Player.new("TestPlayer")], {})
+            end.to raise_error("No image found for item #{test_player.to_s} in image hash")
+            expect do
+                SimpleDialog.generate_dialog_options([test_card], {})
+            end.to  raise_error("No image found for item #{test_card.to_s} in image hash")
+
+            # test
+            #  none of the above calls should fail
+        end
     end
 
     describe "set_prompt" do

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -6,6 +6,22 @@ describe "SimpleDialog" do
 
     test_outfile = Tempfile.new 'test_output'
 
+    describe "generate_prompt_options" do
+        it "should require items in the list to respond  to to_s" do
+            # setup
+            test_player = Player.new("TestPlayer")
+            test_card = Card.new
+
+            # execute
+            SimpleDialog.generate_dialog_options(["Yes", "No"], {"Yes" => "Some yes image", "No" => "Some no image"})
+            SimpleDialog.generate_dialog_options([test_player], {test_player.to_s => "testplayer image"})
+            SimpleDialog.generate_dialog_options([test_card], {test_card.to_s => "testcard image"})
+
+            # test
+            #  none of the above calls should fail
+        end
+    end
+
     describe "set_prompt" do
         it "should not call draw_text on font when prompt symbol is passed" do
             # setup


### PR DESCRIPTION
Since I have started doing the work to utilize statically built button assets all that's left is generating them. Here is that code. Right now this will be a no-op since nothing is utilizing this collection of images, but having this setup will allow for quick turn around on already done work coming shortly after.

_Note: this is in a PR stack (#77, #78, #79). To view effective diff go [here](https://github.com/jjm3x3/flux/compare/feature/new-deck-and-another-warning...feature/create-button-image-repo)