### PR TITLE
Feature/update dialog options

### DIFF
--- a/game_gui.rb
+++ b/game_gui.rb
@@ -283,7 +283,8 @@ class GameGui < Gosu::Window
     # "TrueGuiInterface" stuff... well it used to be
     def display_list_dialog(list, prompt_key)
         @logger.debug "GameGui::display_list_dialog called with prompt_key: '#{prompt_key}'"
-        @list_dialog.set_options(list)
+        dialog_options = SimpleDialog.generate_dialog_options(list, @button_images)
+        @list_dialog.set_options(dialog_options)
         @list_dialog.set_prompt prompt_key
         @list_dialog.reset_result
         @list_dialog.show

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -197,7 +197,8 @@ class GameGui < Gosu::Window
                 @card_played = false
                 if @new_game_driver.await.has_winner.value
                     # win flow
-                    @simple_dialog.set_options(["Back to Main Menu"])
+                    dialog_options = SimpleDialog.generate_dialog_options(["Back to Main Menu"], @button_images)
+                    @simple_dialog.set_options(dialog_options)
                     @simple_dialog.set_prompt(:exit)
                     @simple_dialog.show
                 elsif

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -45,7 +45,15 @@ class GameGui < Gosu::Window
             dialog_prompts,
             @button_options)
 
-        @simple_dialog.set_options(["Yes", "No"])
+        @button_images = {
+            "Yes" => Gosu::Image.from_text("Yes", 20),
+            "No" => Gosu::Image.from_text("No", 20),
+            "Clockwise" => Gosu::Image.from_text("Clockwise", 20),
+            "Counter Clockwise" => Gosu::Image.from_text("Counter Clockwise", 20),
+            "Back to Main Menu" => Gosu::Image.from_text("Back to Main Menu", 20),
+        }
+
+        @simple_dialog.set_options(SimpleDialog.generate_dialog_options(["Yes", "No"], @button_images))
         @simple_dialog.set_prompt :play_a_game_prompt
 
         @list_dialog = CardDialog.new(
@@ -59,13 +67,6 @@ class GameGui < Gosu::Window
         @user_prompt_templates = user_prompt_templates
         @deck = deck
 
-        @button_images = {
-            "Yes": Gosu::Image.from_text("Yes", 20),
-            "No": Gosu::Image.from_text("No", 20),
-            "Clockwise": Gosu::Image.from_text("Clockwise", 20),
-            "Counter Clockwise": Gosu::Image.from_text("Counter Clockwise", 20),
-            "Back to Main Menu": Gosu::Image.from_text("Back to Main Menu", 20),
-        }
         @button_images = @button_images.merge(create_card_images(@deck))
 
         @new_game_driver = nil

--- a/gui_elements/button.rb
+++ b/gui_elements/button.rb
@@ -1,5 +1,6 @@
 class Button
-    def initialize(window, font, text, x, y, z, options={}, image=nil)
+    attr_reader :id
+    def initialize(window, font, text, x, y, z, options={}, image=nil, id=0)
         @window = window
         @text = text
         @x = x
@@ -7,6 +8,7 @@ class Button
         @z = z
         @font = font
         @image = image
+        @id = id
         @visible = true
         @is_pressed = options[:is_pressed]
         @pressed_color = options[:pressed_color]

--- a/gui_elements/button.rb
+++ b/gui_elements/button.rb
@@ -40,6 +40,14 @@ class Button
         @y = y
     end
 
+    def height
+        if @image
+            @image.height
+        else
+            @font.height
+        end
+    end
+
     private
     def intersects
         x_max = 0

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -45,21 +45,25 @@ class SimpleDialog
         @dialog_prompts[symbol] = prompt_image
     end
 
-    def set_options(list)
-        @option_list = list
+    def set_options(list_of_options)
+        @option_map = {}
         @option_buttons = []
         items_displayed = 1 # accounts for prompt
-        list.each do |card|
-            #TODO:: need to generate these statically
+        card_index = 0
+        list_of_options.each do |list_option|
             @option_buttons << Button.new(
                                 @window,
-                                @font,
-                                "#{card}",
+                                nil,
+                                nil,
                                 dialog_content_x_position,
                                 dialog_content_y_position + @item_spacing * items_displayed + @font.height * items_displayed,
                                 ZOrder::DIALOG_ITEMS,
-                                @button_options)
+                                @button_options,
+                                list_option[:image],
+                                card_index)
+            @option_map[card_index] = list_option[:item]
             items_displayed += 1
+            card_index += 1
         end
         # note cardsDisaplyed is really cardsDisplayed + 1 for the prompt
         @height = (@font.height + @item_spacing) * items_displayed + @boarder_width * 2
@@ -111,14 +115,12 @@ class SimpleDialog
     end
 
     def handle_result
-        option_index = 0
         @option_buttons.each do |option_button|
             if option_button.is_clicked?
-                selected_option = @option_list[option_index]
+                selected_option = @option_map[option_button.id]
                 @logger.debug "#{selected_option} was selected"
-                yield @option_list[option_index]
+                yield selected_option
             end
-            option_index += 1
         end
     end
 
@@ -180,15 +182,13 @@ class AsyncDialog < SimpleDialog
     end
 
     def handle_result
-        option_index = 0
         @option_buttons.each do |option_button|
             if option_button.is_clicked?
-                selected_option = @option_list[option_index]
+                selected_option = @option_map[option_button.id]
                 @logger.debug "CardDialog::handle_result: #{selected_option} was selected"
                 @selected_option = selected_option
                 return true
             end
-            option_index += 1
         end
         return false
     end

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -31,7 +31,8 @@ class SimpleDialog
         @item_spacing = 10
 
         # height is assigned fairly arbitrarily here (assumes 3 options and prompt = 4)
-        @height = (@font.height + @item_spacing) * 4 + @boarder_width * 2
+        assumed_font_height = 20  # TODO:: fix this just a hack to get out of depending on @font in ctor
+        @height = (assumed_font_height + @item_spacing) * 4 + @boarder_width * 2
         @width = 300
     end
 

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -49,25 +49,25 @@ class SimpleDialog
     def set_options(list_of_options)
         @option_map = {}
         @option_buttons = []
-        items_displayed = 1 # accounts for prompt
         card_index = 0
+        height_counter = @current_prompt_image.height + @item_spacing
         list_of_options.each do |list_option|
             @option_buttons << Button.new(
                                 @window,
                                 nil,
                                 nil,
                                 dialog_content_x_position,
-                                dialog_content_y_position + @item_spacing * items_displayed + @font.height * items_displayed,
+                                dialog_content_y_position + height_counter,
                                 ZOrder::DIALOG_ITEMS,
                                 @button_options,
                                 list_option[:image],
                                 card_index)
+            height_counter += list_option[:image].height + @item_spacing
             @option_map[card_index] = list_option[:item]
-            items_displayed += 1
             card_index += 1
         end
         # note cardsDisaplyed is really cardsDisplayed + 1 for the prompt
-        @height = (@font.height + @item_spacing) * items_displayed + @boarder_width * 2
+        @height = height_counter + @boarder_width * 2
     end
 
     def draw

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -151,12 +151,13 @@ class SimpleDialog
 
     def set_content_position
         cardsDisplayed = 1 # accounts for prompt
+        height_counter = @current_prompt_image.height + @item_spacing
         @option_buttons.each do |button|
             button.set_position(
                 dialog_content_x_position,
-                dialog_content_y_position + @item_spacing * cardsDisplayed + @font.height * cardsDisplayed,
+                dialog_content_y_position + height_counter
             )
-            cardsDisplayed += 1
+            height_counter += button.height + @item_spacing
         end
     end
 

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -42,6 +42,34 @@ describe "SimpleDialog" do
         end
     end
 
+    describe "initialize" do
+        it "should support constructing without a font" do
+            # setup
+            gui_double = double("gui")
+            background_double = double("background", width: 1, height: 1, draw: nil)
+            font_double = instance_double("font", height: 1)
+            input_stream = StringIO.new("")
+            test_logger = Logger.new(test_outfile)
+            prompt_image_double = double("prompt image", width: 1, draw: nil)
+            expected_prompt_key = :some_expected_prompt
+
+            # execute
+            sut = SimpleDialog.new(
+                gui_double,
+                background_double,
+                nil,
+                test_logger,
+                dialog_prompts={expected_prompt_key => prompt_image_double},
+                button_options={})
+
+
+            expect(font_double).not_to receive(:draw_text).with(any_args)
+
+            # test
+            expect(sut).not_to be nil
+        end
+    end
+
     describe "set_prompt" do
         it "should not call draw_text on font when prompt symbol is passed" do
             # setup
@@ -204,7 +232,8 @@ describe "SimpleDialog" do
             prompt_image_double = double("prompt image", width: 400, draw: nil)
             # This test is mostly asserting that the following calculation with
             # all assumptions and constants is executed
-            expected_height = (font_double.height + 10) * 4 + 20 * 2
+            assumed_font_height = 20  # needs to match the constant in the dialog ctor
+            expected_height = (assumed_font_height + 10) * 4 + 20 * 2
             expected_prompt_key = :some_expected_prompt
             sut = SimpleDialog.new(
                 gui_double,

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -231,7 +231,11 @@ describe "SimpleDialog" do
             font_double = instance_double("font", height: 1, draw_text: nil)
             test_logger = Logger.new(test_outfile)
             prompt_image_double = double("prompt image", width: 400, draw: nil)
-            mock_card_list = [1,2,3]
+            mock_card_list = [
+                {item: 1, image: double("image1", draw: nil)},
+                {item: 2, image: double("image2", draw: nil)},
+                {item: 3, image: double("image3", draw: nil)},
+            ]
             # This test is mostly asserting that the following calculation with
             # all assumptions and constants is executed
             expected_height = (font_double.height + 10) * (mock_card_list.length + 1) + 20 * 2
@@ -263,7 +267,11 @@ describe "SimpleDialog" do
             font_double = instance_double("font", height: 5, text_width: 20, draw_text: nil)
             test_logger = Logger.new(test_outfile)
             prompt_image_double = double("prompt image")
-            mock_card_list = [1,2,3]
+            mock_card_list = [
+                {item: 1, image: double("image1", width: 20, height: 5)},
+                {item: 2, image: double("image2", width: 0, height: 0)},
+                {item: 3, image: double("image3", width: 0, height: 0)},
+            ]
             sut = SimpleDialog.new(
                 gui_double,
                 background_double,

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -333,7 +333,7 @@ describe "SimpleDialog" do
             background_double = double("background", width: 1, height: 1, draw: nil)
             font_double = instance_double("font", height: 5)
             test_logger = Logger.new(test_outfile)
-            prompt_image_double = double("prompt image", width: 400, draw: nil)
+            prompt_image_double = double("prompt image", width: 400, height: 200, draw: nil)
             expected_prompt_key = :some_expected_prompt
             expected_x = 50
             expected_y = 100
@@ -389,7 +389,7 @@ describe "SimpleDialog" do
             background_double = double("background", width: 10, height: 10, draw: nil)
             font_double = instance_double("font", height: 5)
             test_logger = Logger.new(test_outfile)
-            prompt_image_double = double("prompt image", width: 40, draw: nil)
+            prompt_image_double = double("prompt image", width: 40, height: 20, draw: nil)
             expected_prompt_key = :some_expected_prompt
             draged_to_x = 130
             draged_to_y = 160

--- a/tests/gui_elements/dialog_spec.rb
+++ b/tests/gui_elements/dialog_spec.rb
@@ -253,21 +253,23 @@ describe "SimpleDialog" do
             expect(background_double).to have_received(:draw).with(anything, anything, anything, anything, expected_height)
         end
 
-        it "should call draw with a height that is based on how many cards are set" do
+        it "should call draw with a height that is based on cumulative height of promt and button images" do
             # setup
             gui_double = double("gui")
             background_double = double("background", width: 1, height: 1, draw: nil)
             font_double = instance_double("font", height: 1, draw_text: nil)
             test_logger = Logger.new(test_outfile)
-            prompt_image_double = double("prompt image", width: 400, draw: nil)
+            prompt_image_double = double("prompt image", width: 400, height: 5, draw: nil)
             mock_card_list = [
-                {item: 1, image: double("image1", draw: nil)},
-                {item: 2, image: double("image2", draw: nil)},
-                {item: 3, image: double("image3", draw: nil)},
+                {item: 1, image: double("image1", height: 10, draw: nil)},
+                {item: 2, image: double("image2", height: 20, draw: nil)},
+                {item: 3, image: double("image3", height: 30, draw: nil)},
             ]
             # This test is mostly asserting that the following calculation with
             # all assumptions and constants is executed
-            expected_height = (font_double.height + 10) * (mock_card_list.length + 1) + 20 * 2
+            expected_height = (prompt_image_double.height + 10) + mock_card_list.reduce(0) do |add, item|
+                add += item[:image].height + 10
+            end + (20 * 2) # last part is border
             expected_prompt_key = :some_expected_prompt
             sut = SimpleDialog.new(
                 gui_double,
@@ -295,7 +297,7 @@ describe "SimpleDialog" do
             background_double = double("background")
             font_double = instance_double("font", height: 5, text_width: 20, draw_text: nil)
             test_logger = Logger.new(test_outfile)
-            prompt_image_double = double("prompt image")
+            prompt_image_double = double("prompt image", height: 5)
             mock_card_list = [
                 {item: 1, image: double("image1", width: 20, height: 5)},
                 {item: 2, image: double("image2", width: 0, height: 0)},
@@ -306,7 +308,7 @@ describe "SimpleDialog" do
                 background_double,
                 font_double,
                 test_logger,
-                dialog_prompts={},
+                dialog_prompts={default: prompt_image_double},
                 button_options={is_pressed: -> () {} })
             sut.set_options(mock_card_list)
             sut.show


### PR DESCRIPTION
This is really the crux of most of the changes necessary to use static buttons. This is because as soon as we want to start sending images into dialogs `set_options` call we need to carefully consider how this can be done cleanly.
Solutions explored/considered were 
- Two parallel lists
- Injecting all the images on construction/adding in ones that must be created lazily (user dependent ones)
- Creating new objects
- Constructing a hash on the fly
All but the last one had some flaws in their thinking or seemed difficulty to maintain at the least so I went with the last approach.

_Note: this is in a PR stack with (#77 #78 #79 #80). for an effective diff check [here](https://github.com/jjm3x3/flux/compare/feature/create-button-image-repo...feature/update-dialog-options)_