### PR TITLE
Feature/remove font and text for image

### DIFF
--- a/game_gui.rb
+++ b/game_gui.rb
@@ -19,7 +19,7 @@ class GameGui < Gosu::Window
 
         @left_click_down = false
         @button_options = {pressed_color: Gosu::Color::BLACK, unpressed_color: Gosu::Color::WHITE, is_pressed: method(:is_left_button_pressed)}
-        @new_game_button = Button.new(self, nil, nil, 10, 10, ZOrder::GAME_ITEMS, @button_options, Gosu::Image.from_text("New Game?", 20))
+        @new_game_button = Button.new(self, Gosu::Image.from_text("New Game?", 20), 10, 10, ZOrder::GAME_ITEMS, @button_options)
         @game_stats = GameStats.new(10, 10)
         @game = nil
         @current_displayed_cards = []
@@ -260,7 +260,7 @@ class GameGui < Gosu::Window
             cardsDisplayed = 0
             @current_displayed_cards = []
             activePlayer.hand.each do |card|
-                newCardButton = Button.new(self, nil, nil, 20, (permanents_start_y + permanents_height + 10 + @font.height) + 10 * cardsDisplayed + @font.height * cardsDisplayed, ZOrder::GAME_ITEMS, @button_options, Gosu::Image.from_text("#{card}", 20))
+                newCardButton = Button.new(self, Gosu::Image.from_text("#{card}", 20), 20, (permanents_start_y + permanents_height + 10 + @font.height) + 10 * cardsDisplayed + @font.height * cardsDisplayed, ZOrder::GAME_ITEMS, @button_options)
                 newCardButton.draw
                 @current_displayed_cards << newCardButton
                 cardsDisplayed += 1

--- a/gui_elements/button.rb
+++ b/gui_elements/button.rb
@@ -1,13 +1,11 @@
 class Button
     attr_reader :id
-    def initialize(window, font, text, x, y, z, options={}, image=nil, id=0)
+    def initialize(window, image, x, y, z, options={}, id=0)
         @window = window
-        @text = text
+        @image = image
         @x = x
         @y = y
         @z = z
-        @font = font
-        @image = image
         @id = id
         @visible = true
         @is_pressed = options[:is_pressed]

--- a/gui_elements/button.rb
+++ b/gui_elements/button.rb
@@ -19,11 +19,7 @@ class Button
         left_click_down = @is_pressed.call
 
         textcolor = left_click_down && intersects ? @pressed_color : @unpressed_color
-        if @image
-            @image.draw(@x , @y, @z, 1, 1, textcolor)
-        else
-            @font.draw_text(@text, @x , @y, @z , 1.0, 1.0, textcolor)
-        end
+        @image.draw(@x , @y, @z, 1, 1, textcolor)
     end
 
     def is_clicked?

--- a/gui_elements/button.rb
+++ b/gui_elements/button.rb
@@ -50,15 +50,8 @@ class Button
 
     private
     def intersects
-        x_max = 0
-        y_max = 0
-        if @image
-            x_max = @image.width
-            y_max = @image.height
-        else
-            x_max = @font.text_width(@text)
-            y_max = @font.height
-        end
+        x_max = @image.width
+        y_max = @image.height
         mouse_past_left = @window.mouse_x > @x
         mouse_past_right = @window.mouse_x >= @x + x_max
         mouse_below_top = @window.mouse_y > @y

--- a/gui_elements/dialog.rb
+++ b/gui_elements/dialog.rb
@@ -54,13 +54,11 @@ class SimpleDialog
         list_of_options.each do |list_option|
             @option_buttons << Button.new(
                                 @window,
-                                nil,
-                                nil,
+                                list_option[:image],
                                 dialog_content_x_position,
                                 dialog_content_y_position + height_counter,
                                 ZOrder::DIALOG_ITEMS,
                                 @button_options,
-                                list_option[:image],
                                 card_index)
             height_counter += list_option[:image].height + @item_spacing
             @option_map[card_index] = list_option[:item]

--- a/tests/gui_elements/button_spec.rb
+++ b/tests/gui_elements/button_spec.rb
@@ -20,7 +20,8 @@ describe "Button" do
             # setup
             window_double = double("window")
             font_double = double("font", draw_text: nil)
-            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} })
+            image_double = double("image", draw: nil)
+            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} }, image_double)
 
             # execute
             sut.draw
@@ -65,7 +66,8 @@ describe "Button" do
             # setup
             window_double = double("window")
             font_double = double("font", draw_text: nil)
-            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} })
+            image_double = double("image", draw: nil)
+            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} }, image_double)
             expected_x = 100
             expected_y = 100
 
@@ -74,7 +76,7 @@ describe "Button" do
             sut.draw
 
             # assert
-            expect(font_double).to have_received(:draw_text).with(anything, expected_x, expected_y, anything, anything, anything, anything)
+            expect(image_double).to have_received(:draw).with(expected_x, expected_y, anything, anything, anything, anything)
         end
     end
 end

--- a/tests/gui_elements/button_spec.rb
+++ b/tests/gui_elements/button_spec.rb
@@ -5,10 +5,10 @@ describe "Button" do
         it "should construct" do
             # setup
             window_double = double("window")
-            font_double = double("font")
+            image_double = double("image", draw: nil)
 
             # execute
-            Button.new(window_double, font_double, "HI", 1,1,1)
+            Button.new(window_double, image_double, 1,1,1)
 
             # assert
             # nothing much to assert just making sure this works
@@ -19,9 +19,8 @@ describe "Button" do
         it "should draw" do
             # setup
             window_double = double("window")
-            font_double = double("font", draw_text: nil)
             image_double = double("image", draw: nil)
-            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} }, image_double)
+            sut = Button.new(window_double, image_double, 1,1,1, {is_pressed: ->() {} })
 
             # execute
             sut.draw
@@ -33,9 +32,8 @@ describe "Button" do
         it "should prefer drawing an image if one is injected" do
             # setup
             window_double = double("window")
-            font_double = double("font", draw_text: nil)
             image_double = double("image", draw: nil)
-            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} }, image_double)
+            sut = Button.new(window_double, image_double, 1,1,1, {is_pressed: ->() {} })
 
             # execute
             sut.draw
@@ -46,12 +44,11 @@ describe "Button" do
     end
 
     describe "is_clicked?" do
-        it "should interset with image when one is provided" do
+        it "should intersect with image" do
             # setup
             window_double = double("window", mouse_x: 150 , mouse_y: 150)
-            font_double = double("font", text_width: 100, height: 100)
             image_double = double("image", width: 200, height: 200)
-            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} }, image_double)
+            sut = Button.new(window_double, image_double, 1,1,1, {is_pressed: ->() {} })
 
             # execute
             result = sut.is_clicked?
@@ -65,9 +62,8 @@ describe "Button" do
         it "should draw based what what is porvided in set_position" do
             # setup
             window_double = double("window")
-            font_double = double("font", draw_text: nil)
             image_double = double("image", draw: nil)
-            sut = Button.new(window_double, font_double, "HI", 1,1,1, {is_pressed: ->() {} }, image_double)
+            sut = Button.new(window_double, image_double, 1,1,1, {is_pressed: ->() {} })
             expected_x = 100
             expected_y = 100
 


### PR DESCRIPTION
Here is a cleanup for #77 once images was added font and text were not immediately removed since they were still used in a few situations. Now that all those situations have been removed we should be able to safely remove font and text and replace it with the necessary `image` param.

_Note: this is in a PR stack (#77 #78 #79 #80 #81). For an effective diff check [here](https://github.com/jjm3x3/flux/compare/feature/update-dialog-options...feature/remove-font-and-text-for-image)_