### PR TITLE
Feature/remove midgame awaits

### DIFF
--- a/game_driver.rb
+++ b/game_driver.rb
@@ -19,9 +19,12 @@ class GameDriver
         @game.resolve_death_rule(active_player)
       end
       drawnCards = @game.drawCards(active_player, :draw_rule)
+      @logger.debug "GameDriver::setup_new_turn: cards drawn at beginning of turn"
       active_player.add_cards_to_hand(drawnCards)
+      @logger.debug "GameDriver::setup_new_turn: cards added to players hand"
       @cardsPlayed = 0
       @cardsDrawn = drawnCards.length
+      @logger.debug "GameDriver::setup_new_turn: New turn has been setup"
     end
 
     def turn_over?
@@ -72,6 +75,7 @@ class GameDriver
     end
 
     def has_winner
+      @logger.debug "GameDriver:has_winner: checking if game has a winner"
       @game.winner
     end
 

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -195,6 +195,7 @@ class GameGui < Gosu::Window
 
         if @new_game_driver
             if @card_played
+                @logger.debug "GameGui::update: Card has been played, update accordingly"
                 @card_played = false
                 if @new_game_driver.await.has_winner.value
                     # win flow

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -114,7 +114,9 @@ class GameGui < Gosu::Window
         @game = Game.new(@logger, GuiInputManager.new(self), players, Random.new, @deck)
         @game.setup
         @new_game_driver = GameDriver.new(@game, @logger)
+        @logger.debug "GameGui::start_a_new_game: Geting cached player"
         @current_cached_player = @new_game_driver.await.active_player.value
+        @logger.debug "GameGui::start_a_new_game: New game started"
     end
 
     def button_up(id)

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -155,9 +155,7 @@ class GameGui < Gosu::Window
                 @logger.debug "Checking card '#{cardButton}'"
                 if cardButton.is_clicked?
                     @logger.debug "Starting awaiting active_player from game_driver"
-                    active_player_result = @new_game_driver.await.active_player
-                    @logger.debug "Get activePlayer value out of await result"
-                    activePlayer = active_player_result.value
+                    activePlayer = @current_cached_player
 
                     @logger.debug "Getting card from players hand"
                     cardToPlay = activePlayer.remove_card_from_hand(clickedCard)


### PR DESCRIPTION
In anticipation of removing all blocking calls and synchronous access causing data races, lets make sure that in the easier places there is no chance of synchronous access. One exception is on game startup, but this should not break and if it does should be easy to fix or refactor out.
- Checking winner
- Checking played card
- Adds some extra logging.