### PR TITLE
Feature/remove writable props from game

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -7,8 +7,8 @@ require "./game_interface.rb"
 
 class Game
 
-    attr_accessor :currentPlayerCounter
-    attr_reader :deck,
+    attr_reader :currentPlayerCounter,
+        :deck,
         :discardPile,
         :goal,
         :players,

--- a/game.rb
+++ b/game.rb
@@ -7,11 +7,12 @@ require "./game_interface.rb"
 
 class Game
 
-  attr_accessor :ruleBase
-  attr_accessor :players
-  attr_accessor :discardPile
-  attr_accessor :currentPlayerCounter
-  attr_reader :deck, :goal
+    attr_accessor :currentPlayerCounter
+    attr_reader :deck,
+        :discardPile,
+        :goal,
+        :players,
+        :ruleBase
 
   def initialize(aLogger, aTrueInterface = CliInterface.new, players=[], aDeck = Deck.new(aLogger), aRandom = Random.new)
 

--- a/game.rb
+++ b/game.rb
@@ -69,6 +69,7 @@ class Game
   end
 
   def progress_turn
+    @logger.debug "Progressing the turn from #{@currentPlayerCounter}"
     @currentPlayerCounter += 1
   end
 

--- a/tests/game_spec.rb
+++ b/tests/game_spec.rb
@@ -133,6 +133,22 @@ describe "game" do
         end
     end
 
+    describe "progress_turn" do
+        it "should not progress too much" do
+            # Test not necessary since
+            # > Ruby automatically converts integers to a large integer class when
+            # > they overflow, so there's (practically) no limit to how big they
+            # > can be.
+            #                       -- https://stackoverflow.com/a/535763
+            # test_logger = Logger.new($stdout)
+            # theGame = Game.new(test_logger)
+
+            # for i in 0..100000000000
+            #     theGame.progress_turn
+            # end
+        end
+    end
+
     describe "removeDownToKeeperLimit" do
         it "should make sure that the player has no more keepers than the current keeper limit" do
             # setup

--- a/tests/game_spec.rb
+++ b/tests/game_spec.rb
@@ -1245,7 +1245,6 @@ describe "game" do
                 theGame.setup
                 theFirstPlayer = theGame.players[0]
                 firstPlayersOriginalCards = theFirstPlayer.hand
-                theGame.currentPlayerCounter = 11
 
                 # execute
                 theGame.rotateHands(theFirstPlayer)
@@ -1331,7 +1330,6 @@ describe "game" do
                 theGame.setup
                 theFirstPlayer = theGame.players[0]
                 firstPlayersOriginalCards = theFirstPlayer.hand
-                theGame.currentPlayerCounter = 11
 
                 # execute
                 theGame.rotateHands(theFirstPlayer)

--- a/tests/game_spec.rb
+++ b/tests/game_spec.rb
@@ -1069,44 +1069,6 @@ describe "game" do
             end
         end
 
-        it "should handle if the currentPlayer is set to a number of a player which does not exist" do
-            # setup
-            numberOfPlayers = 4
-            input_stream = StringIO.new("0\n" * numberOfPlayers)
-            testLogger = Logger.new(test_outfile)
-            players = Player.generate_players(numberOfPlayers)
-            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
-            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
-            theGame = Game.new(testLogger, testInterface, players)
-            theFirstPlayer = theGame.players[0]
-            theGame.currentPlayerCounter = 8
-
-            # execute
-            theGame.everybody_gets_1(theFirstPlayer)
-
-            # test
-            # should just work
-        end
-
-        it "should handle if the currentPlayer mod players.length is not 0" do
-            # setup
-            numberOfPlayers = 4
-            input_stream = StringIO.new("0\n" * numberOfPlayers)
-            testLogger = Logger.new(test_outfile)
-            players = Player.generate_players(numberOfPlayers)
-            player_prompts = PlayerPromptGenerator.generate_prompts(players, Constants::USER_SPECIFIC_PROMPTS)
-            testInterface = TestInterface.new(input_stream, test_outfile, player_prompts)
-            theGame = Game.new(testLogger, testInterface, players)
-            theFirstPlayer = theGame.players[0]
-            theGame.currentPlayerCounter = 9
-
-            # execute
-            theGame.everybody_gets_1(theFirstPlayer)
-
-            # test
-            # should just work
-        end
-
         it "should play creepers imidately if they are drawn" do
             # setup
             numberOfPlayers = 3
@@ -1214,25 +1176,6 @@ describe "game" do
     end
 
     describe "rotate_hands" do
-        it "should handle if the currentPlayer is set to a number of a player which does not exist" do
-            # setup
-            input_stream = StringIO.new("thing")
-            testLogger = Logger.new(test_outfile)
-            testInterface = TestInterface.new(input_stream, test_outfile)
-            numberOfPlayers = 3
-            players = Player.generate_players(numberOfPlayers)
-            theGame = Game.new(testLogger, testInterface, players)
-            theFirstPlayer = theGame.players[0]
-            firstPlayersOriginalCards = theFirstPlayer.hand
-            theGame.currentPlayerCounter = 10
-
-            # execute
-            theGame.rotateHands(theFirstPlayer)
-
-            # test
-            # this should work just fine
-        end
-
         describe "counter clockwise" do
             it "first player should not have the hand they started with" do
                 # setup


### PR DESCRIPTION
This change has been a long time coming. I have been working to remove all `attr_accessors` from the code and this is the final move. Of course there are net fewer tests but that is also because a few of them were operating on some bad or very white box assumptions.

_Note: dependent workflow (#88 ) see effective diff [here](https://github.com/jjm3x3/flux/compare/bugfix/fix-take-another-turn...feature/remove-writable-props-from-game)_