### PR TITLE
Feature/add player state2 no current player in button up

### DIFF
--- a/game_cli.rb
+++ b/game_cli.rb
@@ -21,6 +21,7 @@ class GameCli
         while !is_turn_over
           @interface.await.print_permanents(activePlayer, prompt="here are the permanents you have:")
 
+          # should consider not using choose_from_list since the GUI doesn't
           cardToPlay = @interface.await.choose_from_list(hand, :select_a_card_to_play_prompt).value
           @logger.debug "Card selected is: '#{cardToPlay}'"
 

--- a/game_cli.rb
+++ b/game_cli.rb
@@ -24,7 +24,7 @@ class GameCli
           cardToPlay = @interface.await.choose_from_list(hand, :select_a_card_to_play_prompt).value
           @logger.debug "Card selected is: '#{cardToPlay}'"
 
-          play_result = @new_game_driver.await.play_card(activePlayer, cardToPlay)
+          play_result = @new_game_driver.await.play_card(cardToPlay)
           @logger.debug "What was the play result? '#{play_result.state}'"
           if play_result.state != :fulfilled
             @logger.warn "play_result may not have been fulfilled because: '#{play_result.reason}'"

--- a/game_driver.rb
+++ b/game_driver.rb
@@ -42,6 +42,10 @@ class GameDriver
         return result
     end
 
+    def remove_card_from_active_player(index)
+      active_player.remove_card_from_hand(index)
+    end
+
     def play_card(player, card_to_play)
         @logger.debug "this should get logged sync"
         @game.play_card(card_to_play, player)

--- a/game_driver.rb
+++ b/game_driver.rb
@@ -46,9 +46,9 @@ class GameDriver
       active_player.remove_card_from_hand(index)
     end
 
-    def play_card(player, card_to_play)
+    def play_card(card_to_play)
         @logger.debug "this should get logged sync"
-        @game.play_card(card_to_play, player)
+        @game.play_card(card_to_play, active_player)
         @logger.debug "After card was played"
         @cardsPlayed += 1
         @logger.debug "Increment cards played"

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -168,17 +168,19 @@ class GameGui < Gosu::Window
                         # value is the selected card to play
                         @logger.info "GameGui::update: you clicked a card button #{value}"
                         @play_card_future = @new_game_driver.async.play_card(value)
-                        @play_card_future.add_observer do |time, value|
-                            @card_played = true
-                            update_game_state
-                        end
-
+                        @play_card_future.add_observer(self, :update_after_play)
                     end
                     return
                 end
                 clickedCard += 1
             end
         end
+    end
+
+    def update_after_play(time, value, reason)
+        @logger.debug "GameGui::update_after_play: Starting to execute"
+        @card_played = true
+        update_game_state
     end
 
     def update

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -166,9 +166,7 @@ class GameGui < Gosu::Window
                     card_selected_future = @new_game_driver.async.remove_card_from_active_player(clickedCard)
                     card_selected_future.add_observer do |time, value|
                         # value is the selected card to play
-
-                        @logger.debug "you clicked a card button #{value}"
-
+                        @logger.info "GameGui::update: you clicked a card button #{value}"
                         @play_card_future = @new_game_driver.async.play_card(value)
                         @play_card_future.add_observer do |time, value|
                             @card_played = true

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -199,6 +199,10 @@ class GameGui < Gosu::Window
         end
 
         if @new_game_driver
+            # NOTE:: We are trying to minimize the number of times we make calls
+            #        to the driver so we have a system of boolean flags so that
+            #        it will only fire off a call to the driver when it makes
+            #        sense to do so.
             if @card_played
                 @logger.debug "GameGui::update: Card has been played, update accordingly"
                 @card_played = false

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -161,18 +161,21 @@ class GameGui < Gosu::Window
                 @logger.debug "Checking card '#{cardButton}'"
                 if cardButton.is_clicked?
                     @logger.debug "Starting awaiting active_player from game_driver"
-                    activePlayer = @current_cached_player
 
                     @logger.debug "Getting card from players hand"
-                    cardToPlay = activePlayer.remove_card_from_hand(clickedCard)
-                    @logger.debug "you clicked a card button #{cardToPlay}"
+                    card_selected_future = @new_game_driver.async.remove_card_from_active_player(clickedCard)
+                    card_selected_future.add_observer do |time, value|
+                        # value is the selected card to play
 
-                    @play_card_future = @new_game_driver.async.play_card(activePlayer, cardToPlay)
-                    @play_card_future.add_observer do |time, value|
-                        @card_played = true
-                        update_game_state
+                        @logger.debug "you clicked a card button #{value}"
+
+                        @play_card_future = @new_game_driver.async.play_card(value)
+                        @play_card_future.add_observer do |time, value|
+                            @card_played = true
+                            update_game_state
+                        end
+
                     end
-
                     return
                 end
                 clickedCard += 1

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -160,21 +160,21 @@ class GameGui < Gosu::Window
             @current_displayed_cards.each do |cardButton|
                 @logger.debug "Checking card '#{cardButton}'"
                 if cardButton.is_clicked?
-                    @logger.debug "Starting awaiting active_player from game_driver"
-
                     @logger.debug "Getting card from players hand"
                     card_selected_future = @new_game_driver.async.remove_card_from_active_player(clickedCard)
-                    card_selected_future.add_observer do |time, value|
-                        # value is the selected card to play
-                        @logger.info "GameGui::update: you clicked a card button #{value}"
-                        @play_card_future = @new_game_driver.async.play_card(value)
-                        @play_card_future.add_observer(self, :update_after_play)
-                    end
+                    card_selected_future.add_observer(self, :update_after_card_selected)
                     return
                 end
                 clickedCard += 1
             end
         end
+    end
+
+    def update_after_card_selected(time, value, reason)
+        # value is the selected card to play
+        @logger.info "GameGui::update: you clicked a card button #{value}"
+        @play_card_future = @new_game_driver.async.play_card(value)
+        @play_card_future.add_observer(self, :update_after_play)
     end
 
     def update_after_play(time, value, reason)

--- a/tests/game_driver_spec.rb
+++ b/tests/game_driver_spec.rb
@@ -72,7 +72,7 @@ describe "GameDriver" do
             playerDouble = double("player")
 
             # execute
-            gameDriver.play_card(playerDouble, cardDouble)
+            gameDriver.play_card(cardDouble)
 
             # test
             expect(gameDouble).to have_received(:play_card)


### PR DESCRIPTION
One thing that will have to happen, so that the we can relinquish a hold on the active player is to remove it from the game_gui (ie the game interface) entirely. There is only one place where this object is actually used and that is in the `button_up` method. In order to do this we need to do two things. The first was to get rid of the code that uses the cached player to remove the card from their hand, instead we let the driver handle that and we just put it in an async. The next is what happens after that. Since the GUI did not actually remove the card from the player it holds no notion of what card is meant to be played. Here we can chain futures together and have the future from the card selection call a future to play the card. When we call to play the card we no longer have the active player but the driver does and so again we can rely on the driver having the active player.