### PR TITLE
Feature/reshuffle deck when possible

### DIFF
--- a/deck.rb
+++ b/deck.rb
@@ -31,6 +31,10 @@ class Deck
     drawnCards
   end
 
+  def add_cards(cards)
+    @cards += cards
+  end
+
   def each
     @cards.each do |card|
       yield card

--- a/game.rb
+++ b/game.rb
@@ -57,12 +57,17 @@ class Game
       if drawnCards.length == expectedNumberOfCards
         break
       else
-      # TODO: should shuffle the discard back in the draw at this point
-      if @deck.count == 0
-        @logger.debug "No cards left to draw"
-        break
-      end
-      drawnCards += @deck.drawCards(expectedNumberOfCards - drawnCards.length)
+        if @deck.count == 0
+          if @discardPile.size != 0
+            @logger.debug "No cards left to draw reshuffling deck"
+            @deck.add_cards(@discardPile)
+            @discardPile = []
+          else
+            @logger.warn "There are no cards in the deck or in discard somehow"
+            break
+          end
+        end
+        drawnCards += @deck.drawCards(expectedNumberOfCards - drawnCards.length)
       end
     end
     drawnCards

--- a/tests/game_spec.rb
+++ b/tests/game_spec.rb
@@ -131,6 +131,33 @@ describe "game" do
             # test
             expect(returnedcards.length).to eq 0 # 0 since there are no "real cards to draw"
         end
+
+        it "should reshufle the discard pile into the deck" do
+            # setup
+            input_stream = StringIO.new("")
+            test_logger = Logger.new(test_outfile)
+            testInterface = TestInterface.new(input_stream, test_outfile)
+            players = Player.generate_players(3)
+            stacked_deck = StackedDeck.new(test_logger,
+                [Creeper.new(10000, "screem", "some very scary rule text"),
+                    Creeper.new(10001, "lonelyness", "there is no one there")],
+                startempty=true)
+            theGame = Game.new(test_logger, testInterface, players, stacked_deck)
+            thefirstplayer = theGame.players[0]
+            # fill discard pile
+
+            a_gaol = Goal.new("Some gaol", [1,2],"Some rule text about how this works")
+            theGame.play_card(a_gaol, thefirstplayer)
+            theGame.play_card(a_gaol, thefirstplayer)
+            theGame.play_card(a_gaol, thefirstplayer)
+
+            # execute
+            returnedcards = theGame.drawCards(thefirstplayer, :draw_rule)
+
+            # test
+            expect(returnedcards.length).to eq 1
+            expect(theGame.discardPile.length).to eq 0
+        end
     end
 
     describe "progress_turn" do


### PR DESCRIPTION
Now that we are well into packaging this for play testing we need to make sure we remove all times the game can brick. Here is an easy example where if the deck runs out we should attempt to shuffle cards from the discard back in.

_Note: using dependent PRs so this depends on (#95 , #96 ) ITMT diff [here](https://github.com/jjm3x3/flux/compare/feature/fix-lets-do-that-again...feature/reshuffle-deck-when-possible)_