### PR TITLE
Feature/post game menu

### DIFF
--- a/deck.rb
+++ b/deck.rb
@@ -139,7 +139,6 @@ class StackedDeck < Deck
         card.card_type != "Creeper"
       end
     end
-
   end
 
   def drawACard

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -166,13 +166,16 @@ class GameGui < Gosu::Window
                         @new_game_button.set_visibility false
                         start_a_new_game
                     elsif result == "Back to Main Menu"
+                        @new_game_button.set_visibility true
                         @new_game_driver = nil
                     end
                     # TODO:: do things for other cases
                 end
                 return
             end
+            @logger.debug "GameGui::button_up: no dialogs are visible so processing menu buttons"
             if @new_game_button.is_clicked?
+                @logger.debug "Showing new game dialog since button was clicked"
                 @simple_dialog.show
                 return
             end

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -34,7 +34,7 @@ class GameGui < Gosu::Window
         @game_stats = GameStats.new(@game_stats_and_current_player_base_x, game_stats_y)
         @current_displayed_cards = []
 
-        @player_changed = true
+        @player_changed = false
         @redraw_hand = true
         @card_played = false
 
@@ -143,6 +143,7 @@ class GameGui < Gosu::Window
         end
         @game_state = game_state_result.value
         @logger.debug "GameGui::start_a_new_game: New game started"
+        @player_changed = true
     end
 
     def button_up(id)

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -61,9 +61,6 @@ class GameGui < Gosu::Window
             "no_one" => Gosu::Image.from_text("No One", 20),
         }
 
-        @simple_dialog.set_options(SimpleDialog.generate_dialog_options(["Yes", "No"], @button_images))
-        @simple_dialog.set_prompt :play_a_game_prompt
-
         @list_dialog = CardDialog.new(
             self,
             dialog_background,

--- a/game_gui.rb
+++ b/game_gui.rb
@@ -176,6 +176,8 @@ class GameGui < Gosu::Window
             @logger.debug "GameGui::button_up: no dialogs are visible so processing menu buttons"
             if @new_game_button.is_clicked?
                 @logger.debug "Showing new game dialog since button was clicked"
+                @simple_dialog.set_options(SimpleDialog.generate_dialog_options(["Yes", "No"], @button_images))
+                @simple_dialog.set_prompt :play_a_game_prompt
                 @simple_dialog.show
                 return
             end

--- a/main.rb
+++ b/main.rb
@@ -56,8 +56,8 @@ logger.level = log_level
 logger.debug "Starting up game!"
 boot_strapping_logger.close  # the app/game logger can take it from here
 
-# the_deck = Deck.new(logger)
-the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
+the_deck = Deck.new(logger)
+# the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
 
 if options[:cli]
     players = Player.generate_players(3)

--- a/main.rb
+++ b/main.rb
@@ -56,8 +56,8 @@ logger.level = log_level
 logger.debug "Starting up game!"
 boot_strapping_logger.close  # the app/game logger can take it from here
 
-the_deck = Deck.new(logger)
-# the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
+# the_deck = Deck.new(logger)
+the_deck = StackedDecks.stacked_deck_factory(logger, StackedDecks::QUICK_WIN)
 
 if options[:cli]
     players = Player.generate_players(3)


### PR DESCRIPTION
This cleans up some remaining gaps so that once a game is won the player will be prompted to go back to main menu and will be able to start a new game. To do this a few thing were moved around and the deck was given a setup method to call after construction.

_Note: dependent revisions work flow (#100 & #102 ) for effective diff [go here](https://github.com/jjm3x3/flux/compare/feature/setup-deck-with-game...feature/post-game-menu)_